### PR TITLE
feat: add compacted format for operator

### DIFF
--- a/types/operator_test.go
+++ b/types/operator_test.go
@@ -3,6 +3,7 @@ package types
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"go.yaml.in/yaml/v4"
 )
 
@@ -51,6 +52,50 @@ var (
 		{VerifySVNR, "verifySVNR"},
 		{Within, "within"},
 	}
+	operatorUnmarshalTests = []struct {
+		name     string
+		input    string
+		expected Operator
+	}{
+		{
+			name: "Standard format",
+			input: `name: rx
+value: ^.*$`,
+			expected: Operator{
+				Name:  Rx,
+				Value: "^.*$",
+			},
+		},
+		{
+			name: "Standard format, negated",
+			input: `name: rx
+value: ^.*$
+negate: true`,
+			expected: Operator{
+				Name:   Rx,
+				Value:  "^.*$",
+				Negate: true,
+			},
+		},
+		{
+			name:  "Compact format",
+			input: `rx: ^.*$`,
+			expected: Operator{
+				Name:  Rx,
+				Value: "^.*$",
+			},
+		},
+		{
+			name: "Compact format, negated",
+			input: `rx: ^.*$
+negate: true`,
+			expected: Operator{
+				Name:   Rx,
+				Value:  "^.*$",
+				Negate: true,
+			},
+		},
+	}
 )
 
 func TestOperatorTypeToString(t *testing.T) {
@@ -84,6 +129,19 @@ func TestMarshalOperatorType(t *testing.T) {
 			if string(data) != tt.yamlStr+"\n" {
 				t.Errorf("Expected %q, got %q", tt.yamlStr+"\n", data)
 			}
+		})
+	}
+}
+
+func TestUnmarshalOperator(t *testing.T) {
+	for _, tt := range operatorUnmarshalTests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result Operator
+			err := yaml.Unmarshal([]byte(tt.input), &result)
+			if err != nil {
+				t.Fatalf("Failed to unmarshal: %v", err)
+			}
+			require.Equal(t, tt.expected, result)
 		})
 	}
 }

--- a/types/operators.go
+++ b/types/operators.go
@@ -270,3 +270,47 @@ func (o *Operator) ToString() string {
 		return "@" + o.Name.String()
 	}
 }
+
+func (o Operator) MarshalYAML() (interface{}, error) {
+	mapOperator := make(map[interface{}]interface{})
+	oName, err := o.Name.MarshalYAML()
+	if err != nil {
+		return nil, err
+	}
+	mapOperator[oName] = o.Value
+	return mapOperator, nil
+}
+
+func (o *Operator) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var rawData map[string]interface{}
+	if err := unmarshal(&rawData); err != nil {
+		return err
+	}
+	for k, v := range rawData {
+		switch k {
+		case "negate":
+			negate, ok := v.(bool)
+			if !ok {
+				return fmt.Errorf("negate should be a boolean")
+			}
+			o.Negate = negate
+		case "name":
+			if err := o.SetOperatorName(v.(string)); err != nil {
+				return err
+			}
+		case "value":
+			o.SetOperatorValue(v.(string))
+		default:
+			err := o.SetOperatorName(k)
+			if err != nil {
+				return err
+			}
+			if strVal, ok := v.(string); ok {
+				o.SetOperatorValue(strVal)
+			} else {
+				return fmt.Errorf("operator value should be a string")
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## what
- add a less verbose way to write an operator, resolves #30.
## why
- it's simpler to write as `rx: ^.*$` than 
  ```
  name: rx
  value: ^.*$
  ```