### PR TITLE
feat: phase defaults in global config

### DIFF
--- a/main.go
+++ b/main.go
@@ -108,6 +108,8 @@ func LoadSeclang(input string) types.ConfigurationList {
 
 // PrintSeclang writes seclang directives to files specified in directive list ids.
 func PrintSeclang(configList types.ConfigurationList, dir string) error {
+	configList.PhaseDefaultsToSeclang()
+
 	unfDirs := types.FromCRSLangToUnformattedDirectives(configList)
 
 	for _, dirList := range unfDirs.DirectiveList {
@@ -126,6 +128,13 @@ func ToCRSLang(configList types.ConfigurationList) *types.ConfigurationList {
 	configListWithConditions := types.ToDirectiveWithConditions(configList)
 
 	configListWithConditions.ExtractDefaultValues()
+
+	err := configListWithConditions.ExtractPhaseDefaults()
+
+	if err != nil {
+		panic(err)
+	}
+
 	return configListWithConditions
 }
 


### PR DESCRIPTION
## what
- extract default action directives and append phase defaults values to global config in `Seclang -> CRSLang` flow:
  ```
  global:
    version: OWASP_CRS/4.0.1-dev
    tags:
        - OWASP_CRS
    phases:
        "1":
            comment: | ...
            actions:
                disruptive: pass
                non-disruptive:
                    - log
                    - auditlog
        "2":
            actions:
                disruptive: pass
                non-disruptive:
                    - log
                    - auditlog
  ```
- prepend phase default in the directive list as DefaultActions in `CRSLang -> Seclang ` flow.
## why
- global config section provides better visibility over default configs.