### PR TITLE
feat: var operations to enums

### DIFF
--- a/listener_test.go
+++ b/listener_test.go
@@ -27,7 +27,7 @@ func mustNewActionWithParam[T types.ActionType](action T, param string) types.Ac
 	return newAction
 }
 
-func mustNewSetvarAction(collection types.CollectionName, operation string, vars []types.VarAssignment) types.Action {
+func mustNewSetvarAction(collection types.CollectionName, operation types.VarOperation, vars []types.VarAssignment) types.Action {
 	newAction, err := types.NewSetvarAction(collection, operation, vars)
 	if err != nil {
 		panic(err)
@@ -169,7 +169,7 @@ SecAction \
 									DisruptiveAction: mustNewActionOnly(types.Pass),
 									NonDisruptiveActions: []types.Action{
 										mustNewActionOnly(types.NoLog),
-										mustNewSetvarAction(types.TX, "=", []types.VarAssignment{
+										mustNewSetvarAction(types.TX, types.Assign, []types.VarAssignment{
 											{Variable: "blocking_inbound_anomaly_score", Value: "0"},
 											{Variable: "detection_inbound_anomaly_score", Value: "0"},
 											{Variable: "inbound_anomaly_score_pl1", Value: "0"},
@@ -296,7 +296,7 @@ SecRule REQUEST_LINE "@rx (?i)^(?:get /[^#\?]*(?:\?[^\s\v#]*)?(?:#[^\s\v]*)?|(?:
 									DisruptiveAction: mustNewActionOnly(types.Block),
 									NonDisruptiveActions: []types.Action{
 										mustNewActionWithParam(types.LogData, "%{request_line}"),
-										mustNewSetvarAction(types.TX, "=+", []types.VarAssignment{{Variable: "inbound_anomaly_score_pl1", Value: "%{tx.warning_anomaly_score}"}}),
+										mustNewSetvarAction(types.TX, types.Increment, []types.VarAssignment{{Variable: "inbound_anomaly_score_pl1", Value: "%{tx.warning_anomaly_score}"}}),
 									},
 								},
 							},

--- a/types/actions_test.go
+++ b/types/actions_test.go
@@ -24,7 +24,7 @@ func mustNewActionWithParam[T ActionType](action T, param string) Action {
 	return newAction
 }
 
-func mustNewSetvarAction(collection CollectionName, operation string, vars []VarAssignment) Action {
+func mustNewSetvarAction(collection CollectionName, operation VarOperation, vars []VarAssignment) Action {
 	newAction, err := NewSetvarAction(collection, operation, vars)
 	if err != nil {
 		panic(err)
@@ -52,7 +52,7 @@ flow:
 				NonDisruptiveActions: []Action{
 					mustNewActionOnly(Capture),
 					mustNewActionWithParam(LogData, "Matched Data: %{TX.0} found within %{MATCHED_VAR_NAME}: %{MATCHED_VAR}"),
-					mustNewSetvarAction(TX, "=", []VarAssignment{{Variable: "rfi_parameter_%{MATCHED_VAR_NAME}", Value: ".%{tx.1}"}}),
+					mustNewSetvarAction(TX, Assign, []VarAssignment{{Variable: "rfi_parameter_%{MATCHED_VAR_NAME}", Value: ".%{tx.1}"}}),
 				},
 				FlowActions: []Action{
 					mustNewActionOnly(Chain),
@@ -90,7 +90,7 @@ non-disruptive:
 				DisruptiveAction: mustNewActionOnly(Pass),
 				NonDisruptiveActions: []Action{
 					mustNewActionOnly(NoLog),
-					mustNewSetvarAction(TX, "=", []VarAssignment{
+					mustNewSetvarAction(TX, Assign, []VarAssignment{
 						{Variable: "blocking_inbound_anomaly_score", Value: "0"},
 						{Variable: "detection_inbound_anomaly_score", Value: "0"},
 						{Variable: "inbound_anomaly_score_pl1", Value: "0"},
@@ -130,7 +130,7 @@ non-disruptive:
 				DisruptiveAction: mustNewActionOnly(Pass),
 				NonDisruptiveActions: []Action{
 					mustNewActionOnly(NoLog),
-					mustNewSetvarAction(TX, "=+", []VarAssignment{{Variable: "paramcounter_%{MATCHED_VAR_NAME}", Value: "1"}}),
+					mustNewSetvarAction(TX, Increment, []VarAssignment{{Variable: "paramcounter_%{MATCHED_VAR_NAME}", Value: "1"}}),
 				},
 			},
 		},

--- a/types/condition_directives.go
+++ b/types/condition_directives.go
@@ -240,7 +240,11 @@ func (s *SeclangActions) UnmarshalYAML(value *yaml.Node) error {
 								if cName == UNKNOWN_COLLECTION {
 									return fmt.Errorf("Collection name %s is not valid", cName)
 								}
-								newAct, err := NewSetvarAction(cName, op.(string), parsedAssigns)
+								vOp := stringToVarOperation(op.(string))
+								if vOp == UnknownOp {
+									return fmt.Errorf("invalid setvar action: invalid operation '%s'", op)
+								}
+								newAct, err := NewSetvarAction(cName, vOp, parsedAssigns)
 								if err != nil {
 									return err
 								}
@@ -260,7 +264,7 @@ func (s *SeclangActions) UnmarshalYAML(value *yaml.Node) error {
 										}
 									}
 								}
-								newAct, err := NewSetvarAction(TX, "=", parsedAssigns)
+								newAct, err := NewSetvarAction(TX, Assign, parsedAssigns)
 								if err != nil {
 									return err
 								}


### PR DESCRIPTION
## what
- change var operations (`+`, `=+`, `=-`) from string to enums
## why
- improve type checking