### PR TITLE
chore: update parser version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22.2
 
 require (
 	github.com/antlr4-go/antlr/v4 v4.13.1
-	github.com/coreruleset/seclang_parser v0.2.0
+	github.com/coreruleset/seclang_parser v0.3.0
 	github.com/magefile/mage v1.15.0
 	github.com/stretchr/testify v1.11.1
 	go.yaml.in/yaml/v4 v4.0.0-rc.3

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
 github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
-github.com/coreruleset/seclang_parser v0.2.0 h1:Rj1ZpLZxF2owZg8zgoCx59UUeHBlIxBh85A1WEMvGQU=
-github.com/coreruleset/seclang_parser v0.2.0/go.mod h1:joNgWwutayILH6THEiq2ypgYxmu816pdvVctt0rLRv4=
+github.com/coreruleset/seclang_parser v0.3.0 h1:VRtDGRHkdgeSwMYqwst3s/efx5faf3Panc0FKrPw/lg=
+github.com/coreruleset/seclang_parser v0.3.0/go.mod h1:76tzWdJ918SPf5TFhoBdNLBYWv1Rgna/OaQP3Ui+4tc=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=
@@ -10,8 +10,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-go.yaml.in/yaml/v4 v4.0.0-rc.2 h1:/FrI8D64VSr4HtGIlUtlFMGsm7H7pWTbj6vOLVZcA6s=
-go.yaml.in/yaml/v4 v4.0.0-rc.2/go.mod h1:aZqd9kCMsGL7AuUv/m/PvWLdg5sjJsZ4oHDEnfPPfY0=
 go.yaml.in/yaml/v4 v4.0.0-rc.3 h1:3h1fjsh1CTAPjW7q/EMe+C8shx5d8ctzZTrLcs/j8Go=
 go.yaml.in/yaml/v4 v4.0.0-rc.3/go.mod h1:aZqd9kCMsGL7AuUv/m/PvWLdg5sjJsZ4oHDEnfPPfY0=
 golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842 h1:vr/HnozRka3pE4EsMEg1lgkXJkTFJCVUX+S/ZT6wYzM=

--- a/listener/configuration_directive.go
+++ b/listener/configuration_directive.go
@@ -1,14 +1,14 @@
 package listener
 
 import (
-	"github.com/coreruleset/seclang_parser/parser"
 	"github.com/coreruleset/crslang/types"
+	"github.com/coreruleset/seclang_parser/parser"
 )
 
 func (l *ExtendedSeclangParserListener) EnterEngine_config_directive_with_param(ctx *parser.Engine_config_directive_with_paramContext) {
 	l.configurationDirective = types.NewConfigurationDirective()
 	l.configurationDirective.SetName(ctx.GetText())
-	l.appendComment = l.configurationDirective.GetMetadata().SetComment
+	l.appendComment = l.configurationDirective.GetMetadata().SetComments
 	l.appendDirective = func() {
 		l.DirectiveList.Directives = append(l.DirectiveList.Directives, *l.configurationDirective)
 	}
@@ -21,7 +21,7 @@ func (l *ExtendedSeclangParserListener) EnterEngine_config_directive_with_param(
 func (l *ExtendedSeclangParserListener) EnterEngine_config_sec_cache_transformations(ctx *parser.Engine_config_sec_cache_transformationsContext) {
 	l.configurationDirective = types.NewConfigurationDirective()
 	l.configurationDirective.SetName(ctx.GetText())
-	l.appendComment = l.configurationDirective.GetMetadata().SetComment
+	l.appendComment = l.configurationDirective.GetMetadata().SetComments
 	l.setParam = func(value string) {
 		l.configurationDirective.Parameter = value
 		l.setParam = func(value2 string) {
@@ -38,7 +38,7 @@ func (l *ExtendedSeclangParserListener) EnterOption_list(ctx *parser.Option_list
 func (l *ExtendedSeclangParserListener) EnterString_engine_config_directive(ctx *parser.String_engine_config_directiveContext) {
 	l.configurationDirective = types.NewConfigurationDirective()
 	l.configurationDirective.SetName(ctx.GetText())
-	l.appendComment = l.configurationDirective.GetMetadata().SetComment
+	l.appendComment = l.configurationDirective.GetMetadata().SetComments
 	l.appendDirective = func() {
 		l.DirectiveList.Directives = append(l.DirectiveList.Directives, *l.configurationDirective)
 	}
@@ -55,7 +55,7 @@ func (l *ExtendedSeclangParserListener) EnterSec_marker_directive(ctx *parser.Se
 	if err != nil {
 		panic(err)
 	}
-	l.appendComment = l.configurationDirective.GetMetadata().SetComment
+	l.appendComment = l.configurationDirective.GetMetadata().SetComments
 	l.setParam = func(value string) {
 		l.configurationDirective.Parameter = value
 		l.setParam = doNothingFuncString

--- a/listener/remove.go
+++ b/listener/remove.go
@@ -3,16 +3,16 @@ package listener
 import (
 	"strconv"
 
-	"github.com/coreruleset/seclang_parser/parser"
 	"github.com/coreruleset/crslang/types"
+	"github.com/coreruleset/seclang_parser/parser"
 )
 
 func (l *ExtendedSeclangParserListener) EnterRemove_rule_by_msg(ctx *parser.Remove_rule_by_msgContext) {
 	l.removeDirective = types.RemoveRuleDirective{
 		Kind: types.Remove,
 	}
-	l.appendComment = func(comment string) {
-		l.removeDirective.Metadata.Comment = comment
+	l.appendComment = func(comments []string) {
+		l.removeDirective.Metadata.Comments = comments
 	}
 	l.setParam = func(value string) {
 		l.removeDirective.Msgs = append(l.removeDirective.Msgs, value)
@@ -26,8 +26,8 @@ func (l *ExtendedSeclangParserListener) EnterRemove_rule_by_tag(ctx *parser.Remo
 	l.removeDirective = types.RemoveRuleDirective{
 		Kind: types.Remove,
 	}
-	l.appendComment = func(comment string) {
-		l.removeDirective.Metadata.Comment = comment
+	l.appendComment = func(comments []string) {
+		l.removeDirective.Metadata.Comments = comments
 	}
 	l.setParam = func(value string) {
 		l.removeDirective.Tags = append(l.removeDirective.Tags, value)
@@ -41,8 +41,8 @@ func (l *ExtendedSeclangParserListener) EnterRemove_rule_by_id(ctx *parser.Remov
 	l.removeDirective = types.RemoveRuleDirective{
 		Kind: types.Remove,
 	}
-	l.appendComment = func(comment string) {
-		l.removeDirective.Metadata.Comment = comment
+	l.appendComment = func(comments []string) {
+		l.removeDirective.Metadata.Comments = comments
 	}
 	l.appendDirective = func() {
 		l.DirectiveList.Directives = append(l.DirectiveList.Directives, l.removeDirective)
@@ -79,4 +79,8 @@ func (l *ExtendedSeclangParserListener) EnterRange_end(ctx *parser.Range_endCont
 
 func (l *ExtendedSeclangParserListener) ExitRemove_rule_by_id_int_range(ctx *parser.Remove_rule_by_id_int_rangeContext) {
 	l.removeDirective.IdRanges = append(l.removeDirective.IdRanges, l.idRange)
+}
+
+func (l *ExtendedSeclangParserListener) EnterString_remove_rules_values(ctx *parser.String_remove_rules_valuesContext) {
+	l.setParam(ctx.GetText())
 }

--- a/listener/sec_action.go
+++ b/listener/sec_action.go
@@ -1,8 +1,8 @@
 package listener
 
 import (
-	"github.com/coreruleset/seclang_parser/parser"
 	"github.com/coreruleset/crslang/types"
+	"github.com/coreruleset/seclang_parser/parser"
 )
 
 // SecDefaultAction
@@ -11,7 +11,7 @@ func (l *ExtendedSeclangParserListener) EnterConfig_dir_sec_default_action(ctx *
 	l.appendDirective = func() {
 		l.DirectiveList.Directives = append(l.DirectiveList.Directives, *l.currentDirective.(*types.DefaultAction))
 	}
-	l.appendComment = l.currentDirective.GetMetadata().SetComment
+	l.appendComment = l.currentDirective.GetMetadata().SetComments
 }
 
 // SecAction
@@ -25,5 +25,5 @@ func (l *ExtendedSeclangParserListener) EnterConfig_dir_sec_action(ctx *parser.C
 			l.DirectiveList.Directives = append(l.DirectiveList.Directives, l.currentDirective.(*types.SecAction))
 		}
 	}
-	l.appendComment = l.currentDirective.GetMetadata().SetComment
+	l.appendComment = l.currentDirective.GetMetadata().SetComments
 }

--- a/listener/sec_rule.go
+++ b/listener/sec_rule.go
@@ -1,8 +1,8 @@
 package listener
 
 import (
-	"github.com/coreruleset/seclang_parser/parser"
 	"github.com/coreruleset/crslang/types"
+	"github.com/coreruleset/seclang_parser/parser"
 )
 
 func (l *ExtendedSeclangParserListener) EnterRules_directive(ctx *parser.Rules_directiveContext) {
@@ -16,7 +16,7 @@ func (l *ExtendedSeclangParserListener) EnterRules_directive(ctx *parser.Rules_d
 			l.DirectiveList.Directives = append(l.DirectiveList.Directives, l.currentDirective.(*types.SecRule))
 		}
 	}
-	l.appendComment = l.currentDirective.GetMetadata().SetComment
+	l.appendComment = l.currentDirective.GetMetadata().SetComments
 }
 
 func (l *ExtendedSeclangParserListener) EnterVariables(ctx *parser.VariablesContext) {

--- a/listener/sec_rule_script.go
+++ b/listener/sec_rule_script.go
@@ -1,8 +1,8 @@
 package listener
 
 import (
-	"github.com/coreruleset/seclang_parser/parser"
 	"github.com/coreruleset/crslang/types"
+	"github.com/coreruleset/seclang_parser/parser"
 )
 
 func (l *ExtendedSeclangParserListener) EnterRule_script_directive(ctx *parser.Rule_script_directiveContext) {
@@ -15,5 +15,5 @@ func (l *ExtendedSeclangParserListener) EnterRule_script_directive(ctx *parser.R
 			l.DirectiveList.Directives = append(l.DirectiveList.Directives, l.currentDirective.(*types.SecRuleScript))
 		}
 	}
-	l.appendComment = l.currentDirective.GetMetadata().SetComment
+	l.appendComment = l.currentDirective.GetMetadata().SetComments
 }

--- a/listener/update_actions.go
+++ b/listener/update_actions.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/coreruleset/seclang_parser/parser"
 	"github.com/coreruleset/crslang/types"
+	"github.com/coreruleset/seclang_parser/parser"
 )
 
 func (l *ExtendedSeclangParserListener) EnterUpdate_action_rule(ctx *parser.Update_action_ruleContext) {
@@ -14,8 +14,8 @@ func (l *ExtendedSeclangParserListener) EnterUpdate_action_rule(ctx *parser.Upda
 		fmt.Printf("Appending directive: %v\n", l.currentDirective.(*types.UpdateActionDirective).ToSeclang())
 		l.DirectiveList.Directives = append(l.DirectiveList.Directives, l.currentDirective.(*types.UpdateActionDirective))
 	}
-	l.appendComment = func(comment string) {
-		l.currentDirective.(*types.UpdateActionDirective).Comment = comment
+	l.appendComment = func(comments []string) {
+		l.currentDirective.(*types.UpdateActionDirective).Comments = comments
 	}
 }
 

--- a/listener/update_target.go
+++ b/listener/update_target.go
@@ -3,14 +3,14 @@ package listener
 import (
 	"strconv"
 
-	"github.com/coreruleset/seclang_parser/parser"
 	"github.com/coreruleset/crslang/types"
+	"github.com/coreruleset/seclang_parser/parser"
 )
 
 func (l *ExtendedSeclangParserListener) EnterUpdate_target_by_id(ctx *parser.Update_target_by_idContext) {
 	l.updateTargetDirective = types.NewUpdateTargetDirective()
-	l.appendComment = func(comment string) {
-		l.updateTargetDirective.Metadata.Comment = comment
+	l.appendComment = func(comments []string) {
+		l.updateTargetDirective.Metadata.Comments = comments
 	}
 	l.appendDirective = func() {
 		l.DirectiveList.Directives = append(l.DirectiveList.Directives, l.updateTargetDirective)
@@ -26,8 +26,8 @@ func (l *ExtendedSeclangParserListener) EnterUpdate_target_by_id(ctx *parser.Upd
 
 func (l *ExtendedSeclangParserListener) EnterUpdate_target_by_tag(ctx *parser.Update_target_by_tagContext) {
 	l.updateTargetDirective = types.NewUpdateTargetDirective()
-	l.appendComment = func(comment string) {
-		l.updateTargetDirective.Metadata.Comment = comment
+	l.appendComment = func(comments []string) {
+		l.updateTargetDirective.Metadata.Comments = comments
 	}
 	l.appendDirective = func() {
 		l.DirectiveList.Directives = append(l.DirectiveList.Directives, l.updateTargetDirective)
@@ -39,8 +39,8 @@ func (l *ExtendedSeclangParserListener) EnterUpdate_target_by_tag(ctx *parser.Up
 
 func (l *ExtendedSeclangParserListener) EnterUpdate_target_by_msg(ctx *parser.Update_target_by_msgContext) {
 	l.updateTargetDirective = types.NewUpdateTargetDirective()
-	l.appendComment = func(comment string) {
-		l.updateTargetDirective.Metadata.Comment = comment
+	l.appendComment = func(comments []string) {
+		l.updateTargetDirective.Metadata.Comments = comments
 	}
 	l.appendDirective = func() {
 		l.DirectiveList.Directives = append(l.DirectiveList.Directives, l.updateTargetDirective)

--- a/listener_test.go
+++ b/listener_test.go
@@ -64,20 +64,21 @@ var (
 					{
 						Directives: []types.SeclangDirective{
 							types.CommentMetadata{
-								Comment: `#
-# -- [[ Introduction ]] --------------------------------------------------------
-#
-# The OWASP ModSecurity Core Rule Set (CRS) is a set of generic attack
-# detection rules that provide a base level of protection for any web
-# application. They are written for the open source, cross-platform
-# ModSecurity Web Application Firewall.
-#
-# See also:
-# https://coreruleset.org/
-# https://github.com/coreruleset/coreruleset
-# https://owasp.org/www-project-modsecurity-core-rule-set/
-#
-`,
+								Comments: []string{
+									"",
+									"-- [[ Introduction ]] --------------------------------------------------------",
+									"",
+									"The OWASP ModSecurity Core Rule Set (CRS) is a set of generic attack",
+									"detection rules that provide a base level of protection for any web",
+									"application. They are written for the open source, cross-platform",
+									"ModSecurity Web Application Firewall.",
+									"",
+									"See also:",
+									"https://coreruleset.org/",
+									"https://github.com/coreruleset/coreruleset",
+									"https://owasp.org/www-project-modsecurity-core-rule-set/",
+									"",
+								},
 							},
 						},
 					},
@@ -95,7 +96,7 @@ SecRuleEngine On
 						Directives: []types.SeclangDirective{
 							types.ConfigurationDirective{
 								Kind:      types.ConfigurationKind,
-								Metadata:  &types.CommentMetadata{},
+								Metadata:  types.CommentMetadata{},
 								Name:      "SecRuleEngine",
 								Parameter: "On",
 							},
@@ -148,11 +149,11 @@ SecAction \
 								Metadata: &types.SecRuleMetadata{
 									OnlyPhaseMetadata: types.OnlyPhaseMetadata{
 										CommentMetadata: types.CommentMetadata{
-											Comment: `# Initialize anomaly scoring variables.
-# All _score variables start at 0, and are incremented by the various rules
-# upon detection of a possible attack.
-
-`,
+											Comments: []string{
+												"Initialize anomaly scoring variables.",
+												"All _score variables start at 0, and are incremented by the various rules",
+												"upon detection of a possible attack.",
+											},
 										},
 										Phase: "1",
 									},
@@ -249,28 +250,29 @@ SecRule REQUEST_LINE "@rx (?i)^(?:get /[^#\?]*(?:\?[^\s\v#]*)?(?:#[^\s\v]*)?|(?:
 								Metadata: &types.SecRuleMetadata{
 									OnlyPhaseMetadata: types.OnlyPhaseMetadata{
 										CommentMetadata: types.CommentMetadata{
-											Comment: `#
-# Validate request line against the format specified in the HTTP RFC
-#
-# -=[ Rule Logic ]=-
-#
-# Uses rule negation against the regex for positive security.   The regex specifies the proper
-# construction of URI request lines such as:
-#
-#   "http" "://" authority path-abempty [ "?" query ]
-#
-# It also outlines proper construction for CONNECT, OPTIONS and GET requests.
-#
-# Regular expression generated from regex-assembly/920100.ra.
-# To update the regular expression run the following shell script
-# (consult https://coreruleset.org/docs/development/regex_assembly/ for details):
-#   crs-toolchain regex update 920100
-#
-# -=[ References ]=-
-# https://www.rfc-editor.org/rfc/rfc9110.html#section-4.2.1
-# http://capec.mitre.org/data/definitions/272.html
-#
-`,
+											Comments: []string{
+												"",
+												"Validate request line against the format specified in the HTTP RFC",
+												"",
+												"-=[ Rule Logic ]=-",
+												"",
+												"Uses rule negation against the regex for positive security.   The regex specifies the proper",
+												"construction of URI request lines such as:",
+												"",
+												"  \"http\" \"://\" authority path-abempty [ \"?\" query ]",
+												"",
+												"It also outlines proper construction for CONNECT, OPTIONS and GET requests.",
+												"",
+												"Regular expression generated from regex-assembly/920100.ra.",
+												"To update the regular expression run the following shell script",
+												"(consult https://coreruleset.org/docs/development/regex_assembly/ for details):",
+												"  crs-toolchain regex update 920100",
+												"",
+												"-=[ References ]=-",
+												"https://www.rfc-editor.org/rfc/rfc9110.html#section-4.2.1",
+												"http://capec.mitre.org/data/definitions/272.html",
+												"",
+											},
 										},
 										Phase: "1",
 									},
@@ -330,12 +332,13 @@ SecRule ARGS_GET:fbclid "@rx [a-zA-Z0-9_-]{61,61}" \
 								Metadata: &types.SecRuleMetadata{
 									OnlyPhaseMetadata: types.OnlyPhaseMetadata{
 										CommentMetadata: types.CommentMetadata{
-											Comment: `#
-# -=[ Exclusion rule for 942440 ]=-
-#
-# Prevent FPs against Facebook click identifier
-#
-`,
+											Comments: []string{
+												"",
+												"-=[ Exclusion rule for 942440 ]=-",
+												"",
+												"Prevent FPs against Facebook click identifier",
+												"",
+											},
 										},
 										Phase: "2",
 									},
@@ -484,12 +487,13 @@ SecRule REQUEST_LINE "@streq GET /" \
 								Metadata: &types.SecRuleMetadata{
 									OnlyPhaseMetadata: types.OnlyPhaseMetadata{
 										CommentMetadata: types.CommentMetadata{
-											Comment: `# This file is used as an exception mechanism to remove common false positives
-# that may be encountered.
-#
-# Exception for Apache SSL pinger
-#
-`,
+											Comments: []string{
+												"This file is used as an exception mechanism to remove common false positives",
+												"that may be encountered.",
+												"",
+												"Exception for Apache SSL pinger",
+												"",
+											},
 										},
 										Phase: "1",
 									},
@@ -602,8 +606,9 @@ SecRule REQBODY_PROCESSOR "!@rx (?:URLENCODED|MULTIPART|XML|JSON)" \
 								Metadata: &types.SecRuleMetadata{
 									OnlyPhaseMetadata: types.OnlyPhaseMetadata{
 										CommentMetadata: types.CommentMetadata{
-											Comment: `# Force body variable
-`,
+											Comments: []string{
+												"Force body variable",
+											},
 										},
 										Phase: "1",
 									},
@@ -647,14 +652,14 @@ SecComponentSignature "OWASP_CRS/4.0.1-dev"`,
 						Directives: []types.SeclangDirective{
 							types.ConfigurationDirective{
 								Kind:      types.ConfigurationKind,
-								Metadata:  &types.CommentMetadata{},
+								Metadata:  types.CommentMetadata{},
 								Name:      "SecCollectionTimeout",
 								Parameter: "600",
 							},
 						},
 						Marker: types.ConfigurationDirective{
 							Kind:      types.ConfigurationKind,
-							Metadata:  &types.CommentMetadata{},
+							Metadata:  types.CommentMetadata{},
 							Name:      "SecMarker",
 							Parameter: "END-TEST",
 						},
@@ -663,7 +668,7 @@ SecComponentSignature "OWASP_CRS/4.0.1-dev"`,
 						Directives: []types.SeclangDirective{
 							types.ConfigurationDirective{
 								Kind:      types.ConfigurationKind,
-								Metadata:  &types.CommentMetadata{},
+								Metadata:  types.CommentMetadata{},
 								Name:      "SecComponentSignature",
 								Parameter: "OWASP_CRS/4.0.1-dev",
 							},

--- a/types/condition_directives.go
+++ b/types/condition_directives.go
@@ -349,6 +349,10 @@ func loadConditionDirective(yamlDirective yaml.Node) SeclangDirective {
 		directive := ConfigurationDirective{}
 		err = yaml.Unmarshal(rawDirective, &directive)
 		if err != nil {
+			fmt.Printf("%s %v\n", err.Error(), yamlDirective.Content[2].Value)
+			for _, c := range yamlDirective.Content[3].Content {
+				fmt.Printf("-> %s\n", c.Value)
+			}
 			panic(err)
 		}
 		return directive

--- a/types/defaultaction.go
+++ b/types/defaultaction.go
@@ -29,7 +29,7 @@ func (d DefaultAction) GetActions() *SeclangActions {
 
 func (s DefaultAction) ToSeclang() string {
 	result := ""
-	result += s.Metadata.Comment + "SecDefaultAction \"phase:" + s.Metadata.Phase
+	result += commentsToSeclang(s.Metadata.Comments) + "SecDefaultAction \"phase:" + s.Metadata.Phase
 	actions := s.Actions.ToString()
 	transformations := s.Transformations.ToString()
 	if actions != "" {

--- a/types/metadata.go
+++ b/types/metadata.go
@@ -5,7 +5,7 @@ import (
 )
 
 type Metadata interface {
-	SetComment(value string)
+	SetComments(values []string)
 	SetId(value string)
 	SetPhase(value string)
 	SetMsg(value string)
@@ -17,15 +17,15 @@ type Metadata interface {
 }
 
 type CommentMetadata struct {
-	Comment string `yaml:"comment,omitempty"`
+	Comments []string `yaml:"comments,omitempty"`
 }
 
 func (c CommentMetadata) GetKind() Kind {
 	return UnknownKind
 }
 
-func (c *CommentMetadata) SetComment(value string) {
-	c.Comment = value
+func (c *CommentMetadata) SetComments(values []string) {
+	c.Comments = values
 }
 
 func (c *CommentMetadata) SetId(value string) {
@@ -61,7 +61,27 @@ func (c *CommentMetadata) SetVer(value string) {
 }
 
 func (c CommentMetadata) ToSeclang() string {
-	return c.Comment
+	result := ""
+	for _, comment := range c.Comments {
+		if comment == "" {
+			result += "#\n"
+		} else {
+			result += "# " + comment + "\n"
+		}
+	}
+	return result
+}
+
+func commentsToSeclang(comments []string) string {
+	result := ""
+	for _, comment := range comments {
+		if comment == "" {
+			result += "#\n"
+		} else {
+			result += "# " + comment + "\n"
+		}
+	}
+	return result
 }
 
 type SecRuleMetadata struct {

--- a/types/secaction.go
+++ b/types/secaction.go
@@ -53,7 +53,7 @@ func (s SecAction) ToSeclangWithIdent(initialString string) string {
 	endString := ""
 
 	result := ""
-	result += s.Metadata.Comment + initialString + "SecAction"
+	result += commentsToSeclang(s.Metadata.Comments) + initialString + "SecAction"
 	sortedActions := sortActions(&s)
 	for i, action := range sortedActions {
 		if i == 0 {

--- a/types/seclang_directives.go
+++ b/types/seclang_directives.go
@@ -33,7 +33,7 @@ func (d CommentDirective) ToSeclang() string {
 
 type ConfigurationDirective struct {
 	Kind      Kind                       `yaml:"kind"`
-	Metadata  *CommentMetadata           `yaml:",inline"`
+	Metadata  CommentMetadata            `yaml:",inline"`
 	Name      ConfigurationDirectiveType `yaml:"name"`
 	Parameter string                     `yaml:"parameter"`
 }
@@ -191,7 +191,7 @@ var (
 func NewConfigurationDirective() *ConfigurationDirective {
 	c := new(ConfigurationDirective)
 	c.Kind = ConfigurationKind
-	c.Metadata = new(CommentMetadata)
+	// c.Metadata = new(CommentMetadata)
 	return c
 }
 
@@ -205,13 +205,13 @@ func (c *ConfigurationDirective) SetName(name string) error {
 }
 
 func (c ConfigurationDirective) GetMetadata() Metadata {
-	return c.Metadata
+	return &c.Metadata
 }
 
 // TODO: add quotes around the value when the parameter is a string
 func (c ConfigurationDirective) ToSeclang() string {
 	result := ""
-	if c.Metadata != nil {
+	if len(c.Metadata.Comments) != 0 {
 		result += c.Metadata.ToSeclang()
 	}
 	result += string(c.Name) + " " + c.Parameter

--- a/types/secrule.go
+++ b/types/secrule.go
@@ -111,7 +111,7 @@ func (s SecRule) ToSeclangWithIdent(initialString string) string {
 	endString := ""
 
 	result := ""
-	result += s.Metadata.Comment + initialString + "SecRule "
+	result += commentsToSeclang(s.Metadata.Comments) + "SecRule "
 	vars := VariablesToString(s.Variables, "|")
 	colls := CollectionsToString(s.Collections, "|")
 	if vars != "" && colls != "" {

--- a/types/secrulescript.go
+++ b/types/secrulescript.go
@@ -43,7 +43,7 @@ func (s SecRuleScript) ToSeclangWithIdent(initialString string) string {
 	auxString := ",\\\n" + initialString + "    "
 	endString := ""
 	result := ""
-	result += s.Metadata.Comment + initialString + "SecRuleScript "
+	result += commentsToSeclang(s.Metadata.Comments) + initialString + "SecRuleScript "
 	result += s.ScriptPath + " "
 
 	sortedActions := sortActions(&s)

--- a/types/update_actions.go
+++ b/types/update_actions.go
@@ -3,10 +3,10 @@ package types
 import "strconv"
 
 type UpdateActionDirective struct {
-	Kind    Kind         `yaml:"kind"`
-	Comment string       `yaml:"comment,omitempty"`
-	Id      int          `yaml:"id"`
-	Modify  ModifyAction `yaml:"modify"`
+	Kind     Kind         `yaml:"kind"`
+	Comments []string     `yaml:"comments,omitempty"`
+	Id       int          `yaml:"id"`
+	Modify   ModifyAction `yaml:"modify"`
 }
 
 func (d UpdateActionDirective) GetKind() Kind {
@@ -49,7 +49,7 @@ func (d *UpdateActionDirective) AddTransformation(t string) error {
 }
 
 func (d UpdateActionDirective) ToSeclang() string {
-	result := d.Comment + "SecRuleUpdateActionById " + strconv.Itoa(d.Id) + " \""
+	result := commentsToSeclang(d.Comments) + "SecRuleUpdateActionById " + strconv.Itoa(d.Id) + " \""
 	actionString := ""
 	actionString += d.Modify.Metadata.ToString()
 	if actionString != "" {
@@ -68,7 +68,7 @@ func (d UpdateActionDirective) AppendChainedDirective(directive ChainableDirecti
 	// Do nothing
 }
 
-func (m *UpdateActionMetadata) SetComment(value string) {
+func (m *UpdateActionMetadata) SetComments(values []string) {
 	// Do nothing
 }
 


### PR DESCRIPTION
## what
- update parser version
- update comments type from `string` to `[]string` in order to have one comment per line
- update remove rule listener function
## why
- we were parsing comments as a block and not extracting the content after the hash.

We should adjust the comment handling in CRSLang, since representing comments as a list of strings is not very practical.