### PR TITLE
fix: comment to seclang

### DIFF
--- a/types/metadata.go
+++ b/types/metadata.go
@@ -62,16 +62,7 @@ func (c *CommentMetadata) SetVer(value string) {
 }
 
 func (c CommentMetadata) ToSeclang() string {
-	lines := strings.Split(c.Comment, "\n")
-	res := ""
-	for i, line := range lines {
-		if i != len(lines)-1 || line != "" {
-			res += "# " + line + "\n"
-		} else if i != len(lines)-1 {
-			res += "#\n"
-		}
-	}
-	return res
+	return commentToSeclang(c.Comment)
 }
 
 // commentToSeclang converts comment strings to SecLang format by replacing newlines with newline + #

--- a/types/metadata_test.go
+++ b/types/metadata_test.go
@@ -11,6 +11,11 @@ var (
 		expected string
 	}{
 		{
+			name:     "Empty string",
+			input:    "",
+			expected: "",
+		},
+		{
 			name:     "Single line comment",
 			input:    "This is a simple comment.\n",
 			expected: "# This is a simple comment.\n",


### PR DESCRIPTION
## what
- update the `commentToSeclang` function to properly handle line endings
- add a test to validate the function and prevent unnoticed behaviour in the future
## why
- after the lastast changes, we ended up with unexpected behaviour 