### PR TITLE
chore: update parser version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22.2
 
 require (
 	github.com/antlr4-go/antlr/v4 v4.13.1
-	github.com/coreruleset/seclang_parser v0.3.0
+	github.com/coreruleset/seclang_parser v0.3.1
 	github.com/magefile/mage v1.15.0
 	github.com/stretchr/testify v1.11.1
 	go.yaml.in/yaml/v4 v4.0.0-rc.3

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
 github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
-github.com/coreruleset/seclang_parser v0.3.0 h1:VRtDGRHkdgeSwMYqwst3s/efx5faf3Panc0FKrPw/lg=
-github.com/coreruleset/seclang_parser v0.3.0/go.mod h1:76tzWdJ918SPf5TFhoBdNLBYWv1Rgna/OaQP3Ui+4tc=
+github.com/coreruleset/seclang_parser v0.3.1 h1:dZENx3TkbXwx4Y2wkgNNcmQC6VzeX0uNisQkA2Mojdw=
+github.com/coreruleset/seclang_parser v0.3.1/go.mod h1:76tzWdJ918SPf5TFhoBdNLBYWv1Rgna/OaQP3Ui+4tc=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=

--- a/listener/extended_seclang_parser_listener.go
+++ b/listener/extended_seclang_parser_listener.go
@@ -84,7 +84,8 @@ func (l *ExtendedSeclangParserListener) EnterComment(ctx *parser.CommentContext)
 	if ctx.COMMENT() != nil {
 		// Remove leading space after the hash if any
 		l.comment += strings.TrimPrefix(ctx.COMMENT().GetText(), " ") + "\n"
-	} else {
+		// Ignore initial empty comment lines because YAML libraries do not work well with them
+	} else if l.comment != "" {
 		l.comment += "\n"
 	}
 }

--- a/listener/sec_rule.go
+++ b/listener/sec_rule.go
@@ -1,11 +1,11 @@
 package listener
 
 import (
-	"github.com/coreruleset/seclang_parser/parser"
 	"github.com/coreruleset/crslang/types"
+	"github.com/coreruleset/seclang_parser/parser"
 )
 
-func (l *ExtendedSeclangParserListener) EnterRules_directive(ctx *parser.Rules_directiveContext) {
+func (l *ExtendedSeclangParserListener) EnterEngine_config_rule_directive(ctx *parser.Engine_config_rule_directiveContext) {
 	l.currentDirective = types.NewSecRule()
 	l.currentDirective.(*types.SecRule).SetOperatorName("rx")
 	if l.previousDirective != nil {

--- a/listener_test.go
+++ b/listener_test.go
@@ -64,8 +64,7 @@ var (
 					{
 						Directives: []types.SeclangDirective{
 							types.CommentMetadata{
-								Comment: `
--- [[ Introduction ]] --------------------------------------------------------
+								Comment: `-- [[ Introduction ]] --------------------------------------------------------
 
 The OWASP ModSecurity Core Rule Set (CRS) is a set of generic attack
 detection rules that provide a base level of protection for any web
@@ -248,8 +247,7 @@ SecRule REQUEST_LINE "@rx (?i)^(?:get /[^#\?]*(?:\?[^\s\v#]*)?(?:#[^\s\v]*)?|(?:
 								Metadata: &types.SecRuleMetadata{
 									OnlyPhaseMetadata: types.OnlyPhaseMetadata{
 										CommentMetadata: types.CommentMetadata{
-											Comment: `
-Validate request line against the format specified in the HTTP RFC
+											Comment: `Validate request line against the format specified in the HTTP RFC
 
 -=[ Rule Logic ]=-
 
@@ -329,8 +327,7 @@ SecRule ARGS_GET:fbclid "@rx [a-zA-Z0-9_-]{61,61}" \
 								Metadata: &types.SecRuleMetadata{
 									OnlyPhaseMetadata: types.OnlyPhaseMetadata{
 										CommentMetadata: types.CommentMetadata{
-											Comment: `
--=[ Exclusion rule for 942440 ]=-
+											Comment: `-=[ Exclusion rule for 942440 ]=-
 
 Prevent FPs against Facebook click identifier
 

--- a/types/metadata.go
+++ b/types/metadata.go
@@ -70,7 +70,7 @@ func commentToSeclang(comment string) string {
 	lines := strings.Split(comment, "\n")
 	res := ""
 	for i, line := range lines {
-		if i != len(lines)-1 || line != "" {
+		if i != len(lines)-1 && line != "" {
 			res += "# " + line + "\n"
 		} else if i != len(lines)-1 {
 			res += "#\n"


### PR DESCRIPTION
## what
- update parser version
- remove initial empty line in comment blocks
## why
- yaml.v4 library doesn't support multiline strings with an empty line at the top. It might be a good idea to move to another yaml library