### PR TITLE
fix: add setvar quotes

### DIFF
--- a/.github/workflows/modsec_check.yml
+++ b/.github/workflows/modsec_check.yml
@@ -1,0 +1,50 @@
+name: Validate ModSecurity Rules with Apache
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  modsecurity-syntax:
+    runs-on: ubuntu-latest
+    container:
+      image: rockylinux:9
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          dnf -y install epel-release
+          dnf -y install httpd mod_security
+          dnf -y install golang
+          dnf -y install git
+
+      - name: Clone OWASP CRS Project
+        run: |
+          git clone https://github.com/coreruleset/coreruleset.git crs
+          cd crs
+          git checkout 8edc58f3ef4d664577e14e5132072559ff30cb34
+
+      - name: Generate rules
+        run: |
+          go run . -o output crs/rules/
+          go run . -s -o /etc/httpd/modsecurity.d/activated_rules output.yaml
+          cp crs/rules/*.data /etc/httpd/modsecurity.d/activated_rules/
+
+      - name: Configure ModSecurity
+        run: |
+          cat <<EOF > /etc/httpd/conf.d/mod_security.conf
+          <IfModule security2_module>
+              SecRuleEngine On
+              SecDataDir /tmp
+              Include /etc/httpd/modsecurity.d/activated_rules/*.conf
+          </IfModule>
+          EOF
+
+      - name: Validate config with httpd -t
+        run: |
+          httpd -t

--- a/types/actions.go
+++ b/types/actions.go
@@ -171,9 +171,9 @@ func (a SetvarAction) ToString() string {
 	var result []string
 	// Reconstruct the setvar actions
 	for _, asg := range a.Assignments {
-		result = append(result, SetVar.String()+":"+a.Collection.String()+"."+asg.Variable+a.Operation.String()+asg.Value)
+		result = append(result, SetVar.String()+":'"+a.Collection.String()+"."+asg.Variable+a.Operation.String()+asg.Value+"'")
 	}
-	return strings.Join(result, ", ")
+	return strings.Join(result, ",")
 }
 
 func (a *SetvarAction) AppendAssignment(variable, value string) error {
@@ -189,7 +189,7 @@ func (a SetvarAction) GetAllParams() []string {
 	var result []string
 	// Get all the variables
 	for _, asg := range a.Assignments {
-		res := SetVar.String() + ":" + a.Collection.String() + "." + asg.Variable + a.Operation.String() + asg.Value
+		res := SetVar.String() + ":'" + a.Collection.String() + "." + asg.Variable + a.Operation.String() + asg.Value + "'"
 		result = append(result, res)
 	}
 	return result

--- a/types/actions_test.go
+++ b/types/actions_test.go
@@ -239,3 +239,140 @@ func TestActionStringMethods(t *testing.T) {
 		assert.Equal(t, "unknown", NonDisruptiveUnknown.String())
 	})
 }
+
+func TestActionToStringMethods(t *testing.T) {
+	t.Run("ActionOnly ToString for all action keys", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			action   ActionOnly
+			expected string
+		}{
+			{name: "disruptive allow", action: ActionOnly(Allow.String()), expected: Allow.String()},
+			{name: "disruptive block", action: ActionOnly(Block.String()), expected: Block.String()},
+			{name: "disruptive deny", action: ActionOnly(Deny.String()), expected: Deny.String()},
+			{name: "disruptive drop", action: ActionOnly(Drop.String()), expected: Drop.String()},
+			{name: "disruptive pass", action: ActionOnly(Pass.String()), expected: Pass.String()},
+			{name: "disruptive pause", action: ActionOnly(Pause.String()), expected: Pause.String()},
+			{name: "flow chain", action: ActionOnly(Chain.String()), expected: Chain.String()},
+			{name: "non disruptive auditlog", action: ActionOnly(AuditLog.String()), expected: AuditLog.String()},
+			{name: "non disruptive capture", action: ActionOnly(Capture.String()), expected: Capture.String()},
+			{name: "non disruptive log", action: ActionOnly(Log.String()), expected: Log.String()},
+			{name: "non disruptive multiMatch", action: ActionOnly(MultiMatch.String()), expected: MultiMatch.String()},
+			{name: "non disruptive noauditlog", action: ActionOnly(NoAuditLog.String()), expected: NoAuditLog.String()},
+			{name: "non disruptive nolog", action: ActionOnly(NoLog.String()), expected: NoLog.String()},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				assert.Equal(t, tt.expected, tt.action.ToString())
+			})
+		}
+	})
+
+	t.Run("ActionWithParam ToString for all action keys", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			action   ActionWithParam
+			expected string
+		}{
+			{name: "proxy", action: ActionWithParam{Proxy.String(): "value"}, expected: "proxy:'value'"},
+			{name: "redirect", action: ActionWithParam{Redirect.String(): "value"}, expected: "redirect:'value'"},
+			{name: "skip", action: ActionWithParam{Skip.String(): "value"}, expected: "skip:'value'"},
+			{name: "skipAfter", action: ActionWithParam{SkipAfter.String(): "value"}, expected: "skipAfter:'value'"},
+			{name: "status", action: ActionWithParam{Status.String(): "500"}, expected: "status:'500'"},
+			{name: "xmlns", action: ActionWithParam{XLMNS.String(): "ns"}, expected: "xmlns:'ns'"},
+			{name: "append", action: ActionWithParam{Append.String(): "value"}, expected: "append:'value'"},
+			{name: "ctl", action: ActionWithParam{Ctl.String(): "ruleEngine=Off"}, expected: "ctl:ruleEngine=Off"},
+			{name: "deprecatevar", action: ActionWithParam{DeprecateVar.String(): "value"}, expected: "deprecatevar:'value'"},
+			{name: "exec", action: ActionWithParam{Exec.String(): "value"}, expected: "exec:'value'"},
+			{name: "expirevar", action: ActionWithParam{ExpireVar.String(): "value"}, expected: "expirevar:'value'"},
+			{name: "initcol", action: ActionWithParam{InitCol.String(): "value"}, expected: "initcol:'value'"},
+			{name: "logdata", action: ActionWithParam{LogData.String(): "value"}, expected: "logdata:'value'"},
+			{name: "prepend", action: ActionWithParam{Prepend.String(): "value"}, expected: "prepend:'value'"},
+			{name: "sanitiseArg", action: ActionWithParam{SanitiseArg.String(): "value"}, expected: "sanitiseArg:'value'"},
+			{name: "sanitiseMatched", action: ActionWithParam{SanitiseMatched.String(): "value"}, expected: "sanitiseMatched:'value'"},
+			{name: "sanitiseMatchedBytes", action: ActionWithParam{SanitiseMatchedBytes.String(): "value"}, expected: "sanitiseMatchedBytes:'value'"},
+			{name: "sanitiseRequestHeader", action: ActionWithParam{SanitiseRequestHeader.String(): "value"}, expected: "sanitiseRequestHeader:'value'"},
+			{name: "sanitiseResponseHeader", action: ActionWithParam{SanitiseResponseHeader.String(): "value"}, expected: "sanitiseResponseHeader:'value'"},
+			{name: "setuid", action: ActionWithParam{SetUid.String(): "value"}, expected: "setuid:'value'"},
+			{name: "setrsc", action: ActionWithParam{SetRsc.String(): "value"}, expected: "setrsc:'value'"},
+			{name: "setsid", action: ActionWithParam{SetSid.String(): "value"}, expected: "setsid:'value'"},
+			{name: "setenv", action: ActionWithParam{SetEnv.String(): "value"}, expected: "setenv:'value'"},
+			{name: "setvar", action: ActionWithParam{SetVar.String(): "tx.flag=on"}, expected: "setvar:'tx.flag=on'"},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				assert.Equal(t, tt.expected, tt.action.ToString())
+			})
+		}
+	})
+
+	t.Run("SetvarAction ToString cases", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			action   SetvarAction
+			expected string
+		}{
+			{
+				name: "with string assignments",
+				action: SetvarAction{
+					Collection: TX,
+					Operation:  Assign,
+					Assignments: []VarAssignment{
+						{Variable: "test", Value: "critical"},
+						{Variable: "test2", Value: "payload with spaces"},
+					},
+				},
+				expected: "setvar:'TX.test=critical',setvar:'TX.test2=payload with spaces'",
+			},
+			{
+				name: "numeric assignments",
+				action: SetvarAction{
+					Collection: TX,
+					Operation:  Assign,
+					Assignments: []VarAssignment{
+						{Variable: "counter", Value: "1"},
+						{Variable: "score", Value: "5"},
+					},
+				},
+				expected: "setvar:'TX.counter=1',setvar:'TX.score=5'",
+			},
+			{
+				name: "numeric assignments with increment operation",
+				action: SetvarAction{
+					Collection: TX,
+					Operation:  Increment,
+					Assignments: []VarAssignment{
+						{Variable: "counter", Value: "1"},
+						{Variable: "score", Value: "5"},
+					},
+				},
+				expected: "setvar:'TX.counter=+1',setvar:'TX.score=+5'",
+			},
+			{
+				name: "numeric assignments with decrement operation",
+				action: SetvarAction{
+					Collection: TX,
+					Operation:  Decrement,
+					Assignments: []VarAssignment{
+						{Variable: "counter", Value: "1"},
+						{Variable: "score", Value: "5"},
+					},
+				},
+				expected: "setvar:'TX.counter=-1',setvar:'TX.score=-5'",
+			},
+			{
+				name:     "without assignments",
+				action:   SetvarAction{Collection: TX, Operation: Assign},
+				expected: "",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				assert.Equal(t, tt.expected, tt.action.ToString())
+			})
+		}
+	})
+}


### PR DESCRIPTION
## What
- add single quotes to `setvar` actions.
- add a new pipeline that checks ModSec syntax directly in Apache.
## Why
- `setvar` assignments containing spaces break the Seclang format.
- standardizing the action format improves consistency and readability.