### PR TITLE
docs: add CRSLang v2 evolution plan and architecture decision records

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -155,9 +155,17 @@ future backends for Google Cloud Armor (CEL), AWS WAF, Cloudflare (Wirefilter), 
 others. SecLang generation must be lossless for the CRS ruleset. Features that a target
 cannot express are handled by compiler workarounds or clear error messages.
 
+**Ruleset initialization:** The `crs-setup.conf` + 901 rules two-layer init chain is
+replaced by a `config {}` block that holds user-tunable deployment policy (paranoia
+level, allowed methods, score thresholds, argument limits, etc.). The compiler generates
+all SecLang initialization output — no hand-authored 901 rules, no two-file split. The
+deployer copies `setup.crs.example` and edits it, replacing the current
+`crs-setup.conf.example` workflow.
+
 See [ADR-0009: Language Base Evaluation](adr/0009-language-base-evaluation.md),
-[ADR-0008: Separation of Configuration](adr/0008-configuration-directives.md), and
-[ADR-0010: Multi-Target Compilation](adr/0010-multi-target-compilation.md).
+[ADR-0008: Separation of Configuration](adr/0008-configuration-directives.md),
+[ADR-0010: Multi-Target Compilation](adr/0010-multi-target-compilation.md), and
+[ADR-0012: Ruleset Initialization and Deployment Configuration](adr/0012-ruleset-initialization.md).
 
 ### Phase 1: Typed Field System
 
@@ -325,6 +333,7 @@ At every phase:
 | [0009](adr/0009-language-base-evaluation.md) | 0 | Language Base — HCL, CEL, Expr, or Custom | Proposed |
 | [0008](adr/0008-configuration-directives.md) | 0 | Separation of Configuration from Rule Language | Proposed |
 | [0010](adr/0010-multi-target-compilation.md) | 0 | Multi-Target Compilation Model | Proposed |
+| [0012](adr/0012-ruleset-initialization.md) | 0 | Ruleset Initialization and Deployment Configuration | Proposed |
 | [0001](adr/0001-typed-field-namespace.md) | 1 | Typed Field Namespace | Proposed |
 | [0007](adr/0007-phase-inference.md) | 1 | Phase Inference from Field Types | Proposed |
 | [0003](adr/0003-boolean-algebra.md) | 2 | Boolean Algebra Replacing Chains | Proposed |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,329 @@
+# CRSLang Evolution: From YAML/SecLang to Composable Expressions
+
+## Vision
+
+CRSLang aims to become a modern, composable rule language for web application firewalls.
+Today it is a YAML serialization of ModSecurity's SecLang AST. The goal is to evolve it
+into a standalone expression language where conditions are composed from typed fields,
+piped through transformation functions, and combined with boolean algebra — similar in
+spirit to Cloudflare's Wirefilter or Google's CEL, but purpose-built for the CRS
+ecosystem.
+
+## Current State
+
+CRSLang v1 is a bidirectional translator between SecLang `.conf` files and structured
+YAML. Internally it models SecLang concepts directly:
+
+- **Variables and Collections** — two separate concepts (`REQUEST_METHOD` vs
+  `REQUEST_HEADERS:Content-Type`) mapped from SecLang's target system
+- **Transformations** — a flat ordered list (`t:lowercase,t:urlDecode`) applied before
+  the operator
+- **Operators** — a single operator per condition (`@rx`, `@pm`, `@eq`, etc.)
+- **Actions** — a bag of disruptive, non-disruptive, flow, and data actions
+- **Chains** — sequential rule linking via the `chain` flow action, simulating AND logic
+- **Phases** — string metadata (`"1"` through `"5"`) controlling evaluation order,
+  redundant with the variables used in the rule in most cases
+
+A rule today looks like:
+
+```yaml
+kind: rule
+metadata:
+  id: 920170
+  phase: "1"
+  message: "GET/HEAD with body"
+  severity: WARNING
+conditions:
+  - collections:
+      - name: REQUEST_HEADERS
+        arguments:
+          - Content-Type
+    operator:
+      name: rx
+      value: "^application/json"
+    transformations:
+      - lowercase
+actions:
+  disruptive:
+    action: block
+  non-disruptive:
+    - action: log
+    - action: setvar
+      param: "tx.anomaly_score=+5"
+```
+
+### Strengths
+
+- Lossless round-trip between SecLang and YAML
+- Familiar to CRS maintainers
+- Toolable (YAML parsers are everywhere)
+- Playground with WASM support
+
+### Limitations
+
+- Verbose: a simple rule requires deep nesting
+- SecLang concepts leak through (chains, `count: true` flags, string phases)
+- No boolean composition: `chain` is implicit AND with no OR support at the
+  condition level
+- Transformations are a flat list, not composable with the operator
+- No type safety: everything is a string
+- Cannot express new patterns without adding more YAML structure
+
+## Target State
+
+A rule in the new CRSLang should look like:
+
+```
+rule 920170 (severity: warning) {
+  when request.method |> matches("^(?:GET|HEAD)$")
+   and request.headers["Content-Length"] |> not(matches("^0?$"))
+  then block {
+    tx.anomaly_score += 5
+    log()
+  }
+}
+```
+
+The phase is not declared — it is inferred as `request_headers` (SecLang phase 1) from
+the `request.method` and `request.headers` field references. When exported to SecLang,
+the compiler emits `phase:1` automatically.
+
+Rules that use only cross-phase fields (e.g., `tx.*`) must declare the phase explicitly:
+
+```
+rule 901001 (phase: request_headers, severity: critical) {
+  when count(tx.crs_setup_version) |> eq(0)
+  then deny(status: 500)
+}
+```
+
+Key properties:
+- **Typed fields** with dot-notation and bracket access for maps
+- **Phase inference** from field types — no redundant phase metadata
+- **Pipeline operator** (`|>`) for chaining transformations and terminal predicates
+- **Boolean algebra** (`and`, `or`, `not`, parentheses) replacing chains
+- **Structured action blocks** replacing the action bag
+- **Compile-time validation** — phase/field mismatches caught before deployment
+- **Concise** but readable by security engineers
+
+## Design Principles
+
+1. **Readability first** — CRS rules are read far more than they are written. The syntax
+   must be scannable by security engineers who are not language designers.
+
+2. **Composability** — any field expression should be combinable with any other via
+   boolean operators. No artificial limits from the underlying engine.
+
+3. **Type safety** — fields have types; functions have signatures. Catch errors at parse
+   time, not at runtime.
+
+4. **Backward compatibility** — SecLang import is permanent. YAML remains a supported
+   serialization. The new syntax adds a better authoring format, it does not remove
+   existing ones.
+
+5. **Incremental adoption** — each phase delivers standalone value. The project does not
+   need to complete all phases to be useful.
+
+6. **Engine independence** — CRSLang describes *what* to match, not *how* a specific
+   engine implements it. Compilation targets (Coraza, ModSecurity, cloud WAFs) are
+   separate concerns. Engine configuration (body limits, PCRE tuning, log paths) is
+   explicitly out of scope — it belongs in engine-specific config files, not in the rule
+   language (see [ADR-0008](adr/0008-configuration-directives.md)).
+
+## Evolution Phases
+
+### Phase 0: Foundational Decisions
+
+Two decisions must be made before any IR or syntax work begins, because they shape
+everything downstream.
+
+**Language base:** Should CRSLang adopt an existing language (HCL, with its Terraform
+ecosystem, Sprig function library, and zero parser maintenance) or build a custom parser
+(with pipeline operator, language-level macros, and full control)? Both approaches
+support globals, groups, named function compositions, and boolean conditions. The key
+trade-off is maintenance cost vs syntactic control — and the answer determines how
+Phases 2-4 are designed.
+
+**Scope:** CRSLang describes *what to detect*, not *how to run the engine*. The ~60
+SecLang configuration directives (body limits, PCRE tuning, log paths, etc.) are
+explicitly out of scope. Only rule-adjacent metadata (component signature, default
+actions, markers, app ID) stays in the language.
+
+See [ADR-0009: Language Base Evaluation](adr/0009-language-base-evaluation.md) and
+[ADR-0008: Separation of Configuration](adr/0008-configuration-directives.md).
+
+### Phase 1: Typed Field System
+
+Replace the split `variables` + `collections` model with a unified typed field namespace.
+
+| Current | New |
+|---|---|
+| `variables: [REQUEST_METHOD]` | `request.method` |
+| `collections: [{name: REQUEST_HEADERS, arguments: [Content-Type]}]` | `request.headers["Content-Type"]` |
+| `collections: [{name: TX, arguments: [score], count: true}]` | `count(tx.score)` |
+| `variables: [REMOTE_ADDR]` | `client.ip` |
+
+Work:
+- Define a typed field registry mapping dotted names to types (String, Int, IP, Bytes, Map)
+- Build bidirectional mappings: SecLang variables/collections <-> field names
+- Update the IR to use `Field` instead of separate `Variable`/`Collection`
+- YAML backward compat: old format loads and normalizes to new
+
+A key benefit of typed fields: **phase becomes inferable**. Since each field belongs to a
+known processing phase (`request.headers` → phase 1, `response.body` → phase 4), the
+compiler can derive the phase automatically and catch phase/field mismatches at compile
+time. Phase is only required as explicit metadata for rules that use exclusively
+cross-phase fields (e.g., `tx.*`).
+
+See [ADR-0001: Typed Field Namespace](adr/0001-typed-field-namespace.md) and
+[ADR-0007: Phase Inference](adr/0007-phase-inference.md).
+
+### Phase 2: Boolean Algebra
+
+Replace `chain` actions and implicit logic with explicit boolean expressions.
+
+| Current | New |
+|---|---|
+| Rule + `chain` + chained rule | `condition1 and condition2` |
+| Multiple conditions (implicit OR) | `condition1 or condition2` |
+| Negated operator | `not(condition)` |
+
+Work:
+- Define `Expression` as recursive: `And(Expr, Expr)`, `Or(Expr, Expr)`, `Not(Expr)`,
+  `Predicate(Pipeline)`
+- Eliminate `chain` as a concept
+- Remove `ChainedRule` from the IR
+- Parenthesized grouping for precedence
+
+This is the second core IR change. It does not depend on how functions or actions are
+surfaced syntactically — boolean composition is a structural change to the condition
+model.
+
+See [ADR-0003: Boolean Algebra Replacing Chains](adr/0003-boolean-algebra.md).
+
+### Phase 3: Function Composition and Structured Actions
+
+How functions and actions are expressed depends on the Phase 0 language base decision.
+
+**Function composition** — transformations and operators become composable functions.
+If the custom parser is chosen, a pipeline operator (`|>`) chains them left-to-right.
+If HCL is chosen, named composition functions (macros) keep nesting shallow. Either way,
+reusable transform chains are defined once and invoked by name.
+
+| Current | New (custom) | New (HCL) |
+|---|---|---|
+| `transformations: [lowercase, urlDecode]` + `operator: {name: rx, ...}` | `field \|> url_decode() \|> lowercase() \|> matches("...")` | `matches(normalize(field), "...")` |
+
+**Structured actions** — the action bag is replaced with a structured model. If the
+custom parser is chosen, `then block { tx.score += 5 }` uses native assignment operators.
+If HCL is chosen, effects use structured sub-blocks or string-encoded operations.
+
+| Current | New (custom) | New (HCL) |
+|---|---|---|
+| `disruptive: block` + `setvar: "tx.score=+10"` | `then block { tx.score += 10 }` | `action = "block"` + `effects { tx_score = "+=10" }` |
+
+Work:
+- Define a `Function` type with signature: name, args, return type
+- If custom: implement pipeline operator, language-level macros
+- If HCL: register function library (including Sprig), define macro blocks
+- Redesign actions as structured model (disruptive + effects)
+- `ctl:` directives become `configure {}` blocks
+
+See [ADR-0002: Pipeline Operator](adr/0002-pipeline-operator.md) (custom parser path),
+[ADR-0004: Structured Action Model](adr/0004-structured-actions.md), and
+[ADR-0009: Language Base Evaluation](adr/0009-language-base-evaluation.md).
+
+### Phase 4: Text Syntax and Parser
+
+Implement the text syntax based on the Phase 0 decision.
+
+Both approaches support the core structural requirements:
+- **Globals block** for version, common tags — inherited by all rules
+- **Group blocks** for file-level metadata — tags shared within a logical grouping
+- **Named function compositions** (macros) — reusable transform chains
+- **Boolean conditions** with custom functions for matching
+
+Work:
+- If HCL: define schema, register function library, design effects model
+- If custom: write lexer + recursive-descent parser, build function library
+- YAML becomes one serialization of the IR, not the canonical form
+- SecLang import stays via existing ANTLR parser (read-only)
+- Update WASM/playground for the new syntax
+
+See [ADR-0005: Parser Strategy](adr/0005-parser-strategy.md) and
+[ADR-0009: Language Base Evaluation](adr/0009-language-base-evaluation.md).
+
+### Phase 5: Rule Management Directives
+
+Handle meta-operations (exclusions, target updates, action updates) in the new syntax.
+
+```
+exclude rule 920170
+
+update rule 920170 {
+  remove target request.args["foo"]
+}
+```
+
+Work:
+- First-class exclusion syntax
+- Rule override/extension mechanism
+- Replace `SecRuleRemoveById`, `SecRuleUpdateTargetById`, etc.
+
+See [ADR-0006: Rule Management Directives](adr/0006-rule-management.md).
+
+## Migration Strategy
+
+```
+Phase 0      Decide language base (HCL vs custom) and scope (no engine config).
+             These decisions gate all subsequent work.
+
+Phase 1      Internal IR changes: typed fields, phase inference.
+             YAML syntax updated but backward-compatible.
+             SecLang import still works.
+
+Phase 2      Semantic model change: boolean expressions replace chains.
+             New YAML schema version (v2).
+             Automated migration tool: v1 YAML -> v2 YAML.
+
+Phase 3      Function composition and action model redesign.
+             Shape determined by Phase 0 decision.
+
+Phase 4      Text syntax as primary authoring format.
+             Three importers: SecLang -> IR, YAML -> IR, CRSLang text -> IR.
+             Two exporters: IR -> YAML, IR -> CRSLang text.
+
+Phase 5      Full language with rule management.
+             SecLang becomes legacy import-only.
+```
+
+At every phase:
+- Existing SecLang `.conf` files remain importable
+- Existing v1 YAML remains loadable (with deprecation warnings from Phase 2+)
+- The playground supports all active formats
+- `crs-toolchain` integration is updated in lockstep
+
+## Architecture Decision Records
+
+| ADR | Phase | Title | Status |
+|-----|-------|-------|--------|
+| [0009](adr/0009-language-base-evaluation.md) | 0 | Language Base — HCL, CEL, Expr, or Custom | Proposed |
+| [0008](adr/0008-configuration-directives.md) | 0 | Separation of Configuration from Rule Language | Proposed |
+| [0001](adr/0001-typed-field-namespace.md) | 1 | Typed Field Namespace | Proposed |
+| [0007](adr/0007-phase-inference.md) | 1 | Phase Inference from Field Types | Proposed |
+| [0003](adr/0003-boolean-algebra.md) | 2 | Boolean Algebra Replacing Chains | Proposed |
+| [0002](adr/0002-pipeline-operator.md) | 3 | Pipeline Operator for Composition (conditional on 0009) | Proposed |
+| [0004](adr/0004-structured-actions.md) | 3 | Structured Action Model | Proposed |
+| [0005](adr/0005-parser-strategy.md) | 4 | Parser Strategy (see 0009 for decision) | Proposed |
+| [0006](adr/0006-rule-management.md) | 5 | Rule Management Directives | Proposed |
+
+## Reference Languages
+
+- [Wirefilter](https://developers.cloudflare.com/ruleset-engine/rules-language/) —
+  Cloudflare's flat-field boolean expression language for firewall rules
+- [CEL](https://github.com/google/cel-spec) — Google's Common Expression Language,
+  used in Envoy, Kubernetes, and IAM policies
+- [OPA/Rego](https://www.openpolicyagent.org/docs/latest/policy-language/) —
+  Open Policy Agent's logic-programming policy language
+- [SecLang](https://github.com/owasp-modsecurity/ModSecurity/wiki/Reference-Manual-%28v3.x%29) —
+  ModSecurity's directive-based rule language (current source format)

--- a/docs/README.md
+++ b/docs/README.md
@@ -149,8 +149,15 @@ SecLang configuration directives (body limits, PCRE tuning, log paths, etc.) are
 explicitly out of scope. Only rule-adjacent metadata (component signature, default
 actions, markers, app ID) stays in the language.
 
-See [ADR-0009: Language Base Evaluation](adr/0009-language-base-evaluation.md) and
-[ADR-0008: Separation of Configuration](adr/0008-configuration-directives.md).
+**Multi-target compilation:** CRSLang is not constrained by any single compilation
+target. Today it compiles to SecLang (ModSecurity/Coraza), but the architecture supports
+future backends for Google Cloud Armor (CEL), AWS WAF, Cloudflare (Wirefilter), and
+others. SecLang generation must be lossless for the CRS ruleset. Features that a target
+cannot express are handled by compiler workarounds or clear error messages.
+
+See [ADR-0009: Language Base Evaluation](adr/0009-language-base-evaluation.md),
+[ADR-0008: Separation of Configuration](adr/0008-configuration-directives.md), and
+[ADR-0010: Multi-Target Compilation](adr/0010-multi-target-compilation.md).
 
 ### Phase 1: Typed Field System
 
@@ -214,13 +221,20 @@ reusable transform chains are defined once and invoked by name.
 |---|---|---|
 | `transformations: [lowercase, urlDecode]` + `operator: {name: rx, ...}` | `field \|> url_decode() \|> lowercase() \|> matches("...")` | `matches(normalize(field), "...")` |
 
-**Structured actions** — the action bag is replaced with a structured model. If the
-custom parser is chosen, `then block { tx.score += 5 }` uses native assignment operators.
-If HCL is chosen, effects use structured sub-blocks or string-encoded operations.
+**Structured actions and scoring** — the action bag is replaced with a structured model.
+If the custom parser is chosen, `then block { tx.score += 5 }` uses native assignment
+operators. If HCL is chosen, effects use structured sub-blocks or string-encoded
+operations.
 
-| Current | New (custom) | New (HCL) |
-|---|---|---|
-| `disruptive: block` + `setvar: "tx.score=+10"` | `then block { tx.score += 10 }` | `action = "block"` + `effects { tx_score = "+=10" }` |
+Additionally, **anomaly scoring becomes first-class**: severity-derived scoring
+eliminates the `setvar` boilerplate from every attack detection rule. A rule just declares
+its severity, and the scoring model (defined in globals) handles the rest.
+
+| Current | New |
+|---|---|
+| `disruptive: block` + `setvar: "tx.score=+10"` | `severity: critical` (score auto-derived) |
+| Manual `setvar` per category | Category derived from group membership |
+| Complex phase-5 evaluation rules | `scoring_threshold { inbound = 5 }` |
 
 Work:
 - Define a `Function` type with signature: name, args, return type
@@ -230,7 +244,8 @@ Work:
 - `ctl:` directives become `configure {}` blocks
 
 See [ADR-0002: Pipeline Operator](adr/0002-pipeline-operator.md) (custom parser path),
-[ADR-0004: Structured Action Model](adr/0004-structured-actions.md), and
+[ADR-0004: Structured Action Model](adr/0004-structured-actions.md),
+[ADR-0011: First-Class Scoring](adr/0011-first-class-scoring.md), and
 [ADR-0009: Language Base Evaluation](adr/0009-language-base-evaluation.md).
 
 ### Phase 4: Text Syntax and Parser
@@ -309,11 +324,13 @@ At every phase:
 |-----|-------|-------|--------|
 | [0009](adr/0009-language-base-evaluation.md) | 0 | Language Base — HCL, CEL, Expr, or Custom | Proposed |
 | [0008](adr/0008-configuration-directives.md) | 0 | Separation of Configuration from Rule Language | Proposed |
+| [0010](adr/0010-multi-target-compilation.md) | 0 | Multi-Target Compilation Model | Proposed |
 | [0001](adr/0001-typed-field-namespace.md) | 1 | Typed Field Namespace | Proposed |
 | [0007](adr/0007-phase-inference.md) | 1 | Phase Inference from Field Types | Proposed |
 | [0003](adr/0003-boolean-algebra.md) | 2 | Boolean Algebra Replacing Chains | Proposed |
 | [0002](adr/0002-pipeline-operator.md) | 3 | Pipeline Operator for Composition (conditional on 0009) | Proposed |
 | [0004](adr/0004-structured-actions.md) | 3 | Structured Action Model | Proposed |
+| [0011](adr/0011-first-class-scoring.md) | 3 | First-Class Scoring Model | Proposed |
 | [0005](adr/0005-parser-strategy.md) | 4 | Parser Strategy (see 0009 for decision) | Proposed |
 | [0006](adr/0006-rule-management.md) | 5 | Rule Management Directives | Proposed |
 

--- a/docs/adr/0001-typed-field-namespace.md
+++ b/docs/adr/0001-typed-field-namespace.md
@@ -39,11 +39,11 @@ Fields use a hierarchical dot-separated namespace:
 
 ```
 request.method          # was: REQUEST_METHOD
-request.uri             # was: REQUEST_URI
-request.uri.path        # was: REQUEST_URI (path component)
-request.filename        # was: REQUEST_FILENAME
-request.basename        # was: REQUEST_BASENAME
-request.line            # was: REQUEST_LINE
+request.uri             # was: REQUEST_URI (full URI including query string)
+request.uri_raw         # was: REQUEST_URI_RAW (uri before normalization)
+request.filename        # was: REQUEST_FILENAME (path without query string)
+request.basename        # was: REQUEST_BASENAME (last path component)
+request.line            # was: REQUEST_LINE (raw request line)
 request.protocol        # was: REQUEST_PROTOCOL
 request.body            # was: REQUEST_BODY
 request.body.length     # was: REQUEST_BODY_LENGTH
@@ -67,8 +67,13 @@ client.port             # was: REMOTE_PORT
 server.ip               # was: SERVER_ADDR
 server.port             # was: SERVER_PORT
 
-tx.anomaly_score        # was: TX:anomaly_score
-tx.inbound_score        # was: TX:inbound_anomaly_score_threshold
+tx.anomaly_score                 # was: TX:anomaly_score
+tx.inbound_anomaly_score_pl1     # was: TX:inbound_anomaly_score_pl1
+tx.inbound_anomaly_score_pl2     # was: TX:inbound_anomaly_score_pl2
+tx.inbound_anomaly_score_pl3     # was: TX:inbound_anomaly_score_pl3
+tx.inbound_anomaly_score_pl4     # was: TX:inbound_anomaly_score_pl4
+# Note: CRS stores scores as TX variables. ADR-0011 proposes replacing
+# direct TX access with a first-class scoring model.
 
 matched.var             # was: MATCHED_VAR
 matched.var_name        # was: MATCHED_VAR_NAME

--- a/docs/adr/0001-typed-field-namespace.md
+++ b/docs/adr/0001-typed-field-namespace.md
@@ -1,0 +1,197 @@
+# ADR-0001: Typed Field Namespace
+
+- **Status:** Proposed
+- **Date:** 2026-04-13
+- **Phase:** 1
+
+## Context
+
+CRSLang currently models SecLang's target system directly, splitting targets into two
+separate concepts:
+
+- **Variables** — standalone values like `REQUEST_METHOD`, `REMOTE_ADDR`,
+  `RESPONSE_STATUS`. Represented as a flat enum with 120+ entries.
+- **Collections** — map-like structures like `REQUEST_HEADERS`, `ARGS`, `TX` that
+  require argument selectors (e.g., `REQUEST_HEADERS:Content-Type`). Represented with a
+  `name`, `arguments[]`, `excluded[]`, and a `count` boolean flag.
+
+This dual model creates several problems:
+
+1. **Cognitive overhead** — rule authors must know which targets are variables vs
+   collections. The distinction is a SecLang implementation detail, not a conceptual one.
+2. **Verbose YAML** — accessing `REQUEST_HEADERS:Content-Type` requires 4 lines of YAML
+   nesting.
+3. **Weak typing** — all values are strings. There is no way to express that
+   `REMOTE_ADDR` is an IP address or that `RESPONSE_STATUS` is an integer.
+4. **Count as a flag** — `&COLLECTION` (count) is a boolean on the collection struct
+   rather than a function applied to it.
+5. **No validation** — nothing prevents combining invalid variable/collection names with
+   incompatible operators.
+
+## Decision
+
+Replace variables and collections with a **unified typed field namespace** using
+dot-notation for hierarchy and bracket notation for map access.
+
+### Field Naming Convention
+
+Fields use a hierarchical dot-separated namespace:
+
+```
+request.method          # was: REQUEST_METHOD
+request.uri             # was: REQUEST_URI
+request.uri.path        # was: REQUEST_URI (path component)
+request.protocol        # was: REQUEST_PROTOCOL
+request.body            # was: REQUEST_BODY
+request.headers         # was: REQUEST_HEADERS (entire map)
+request.headers["Host"] # was: REQUEST_HEADERS:Host
+request.cookies         # was: REQUEST_COOKIES (entire map)
+request.cookies["sid"]  # was: REQUEST_COOKIES:sid
+request.args            # was: ARGS (all arguments)
+request.args.get        # was: ARGS_GET
+request.args.post       # was: ARGS_POST
+request.args["id"]      # was: ARGS:id
+
+response.status         # was: RESPONSE_STATUS
+response.body           # was: RESPONSE_BODY
+response.headers        # was: RESPONSE_HEADERS
+
+client.ip               # was: REMOTE_ADDR
+client.port             # was: REMOTE_PORT
+server.ip               # was: SERVER_ADDR
+server.port             # was: SERVER_PORT
+
+tx.anomaly_score        # was: TX:anomaly_score
+tx.inbound_score        # was: TX:inbound_anomaly_score_threshold
+
+matched.var             # was: MATCHED_VAR
+matched.var_name        # was: MATCHED_VAR_NAME
+matched.vars            # was: MATCHED_VARS (map)
+
+multipart.filename      # was: MULTIPART_FILENAME
+multipart.name          # was: MULTIPART_NAME
+
+time.epoch              # was: TIME_EPOCH
+time.year               # was: TIME_YEAR
+
+rule.id                 # was: RULE:id (inside RULE collection)
+```
+
+### Type System
+
+Each field has a declared type:
+
+| Type | Description | Example fields |
+|------|-------------|----------------|
+| `String` | UTF-8 text | `request.method`, `request.uri` |
+| `Int` | Integer | `response.status`, `server.port` |
+| `IP` | IP address (v4/v6) | `client.ip`, `server.ip` |
+| `Bytes` | Raw byte sequence | `request.body`, `response.body` |
+| `Map[String]` | String-keyed map of strings | `request.headers`, `request.args` |
+| `List[String]` | Ordered list of strings | `request.headers.names`, `request.args.names` |
+| `Bool` | Boolean | (future: computed fields) |
+
+### Map Access
+
+Map-typed fields support:
+- **Full map** — `request.headers` (iterates all values)
+- **Key access** — `request.headers["Content-Type"]` (single value, type `String`)
+- **Key exclusion** — `request.headers[!"Cookie"]` (all values except Cookie)
+- **Names** — `request.headers.names` (list of key names)
+
+### Count as a Function
+
+Instead of a boolean flag on the collection, `count()` is a function:
+
+```
+# Current YAML:
+collections:
+  - name: TX
+    arguments: [crs_setup_version]
+    count: true
+
+# New:
+count(tx.crs_setup_version)    # returns Int
+```
+
+### Implementation
+
+1. **Field Registry** — a Go struct/map defining all known fields with their names,
+   types, and SecLang equivalents:
+
+   ```go
+   type FieldDef struct {
+       Name       string     // "request.headers"
+       Type       FieldType  // MapString
+       SecLangVar string     // "REQUEST_HEADERS" (for import/export)
+       IsCollection bool     // true (for backward compat mapping)
+   }
+   ```
+
+2. **IR change** — conditions use `Field` instead of `[]Variable` + `[]Collection`:
+
+   ```go
+   type Target struct {
+       Field     FieldRef   // parsed field reference
+       KeyAccess *string    // bracket key, if any
+       Excluded  []string   // excluded keys
+   }
+   ```
+
+3. **Bidirectional mapping** — for SecLang import and YAML v1 compat:
+   - `REQUEST_HEADERS:Content-Type` -> `request.headers["Content-Type"]`
+   - `&TX:score` -> `count(tx.score)`
+   - `!ARGS:foo` -> `request.args[!"foo"]`
+
+4. **YAML v2 syntax** (intermediate, before Phase 5 text syntax):
+
+   ```yaml
+   conditions:
+     - target: request.headers["Content-Type"]
+       operator:
+         name: rx
+         value: "^application/json"
+   ```
+
+## Alternatives Considered
+
+### A: Keep variables and collections separate, just rename them
+
+Simpler migration but preserves the dual-model complexity and does not enable type
+checking.
+
+### B: Object traversal (CEL-style)
+
+`request.headers.get("Content-Type")` — method calls on typed objects. More powerful
+but requires a more complex runtime model. Could be revisited if CRSLang ever needs
+computed fields or custom methods.
+
+### C: Flat identifiers (Wirefilter-style)
+
+`http.request.headers` with no real hierarchy — dots are part of the name, not
+traversal. Simpler parser but loses the structural grouping that aids readability and
+completion.
+
+## Consequences
+
+### Positive
+
+- Unified mental model: everything is a field
+- Type checking becomes possible
+- Shorter, more readable conditions
+- Natural path to function composition (Phase 2)
+- Bracket notation handles map access, exclusions, and regex selectors uniformly
+
+### Negative
+
+- Large mapping table to maintain (120+ SecLang variables -> field names)
+- Community must learn new field names (mitigated by documentation and autocomplete)
+- Potential naming conflicts with future WAF engines
+- Serialization format must handle both old and new field references during transition
+
+### Risks
+
+- **Naming bikeshed** — field names will be debated. Propose a naming convention early
+  and get community buy-in before implementation.
+- **Incomplete coverage** — some obscure SecLang variables may not map cleanly.
+  Maintain an `engine.*` escape hatch namespace for engine-specific fields.

--- a/docs/adr/0001-typed-field-namespace.md
+++ b/docs/adr/0001-typed-field-namespace.md
@@ -146,11 +146,12 @@ count(tx.crs_setup_version)    # returns Int
 4. **YAML v2 syntax** (intermediate, before Phase 5 text syntax):
 
    ```yaml
-   conditions:
-     - target: request.headers["Content-Type"]
-       operator:
-         name: rx
-         value: "^application/json"
+   when:
+     pipeline:
+       field: request.headers["Content-Type"]
+       steps:
+         - fn: matches
+           args: ["^application/json"]
    ```
 
 ## Alternatives Considered

--- a/docs/adr/0001-typed-field-namespace.md
+++ b/docs/adr/0001-typed-field-namespace.md
@@ -107,8 +107,25 @@ Each field has a declared type:
 Map-typed fields support:
 - **Full map** — `request.headers` (iterates all values)
 - **Key access** — `request.headers["Content-Type"]` (single value, type `String`)
-- **Key exclusion** — `request.headers[!"Cookie"]` (all values except Cookie)
 - **Names** — `request.headers.names` (list of key names)
+
+**Key exclusions** (SecLang's `!ARGS:foo` — "iterate all keys except foo") are not part
+of the field syntax. Instead, target exclusions are handled by the rule management system
+(ADR-0006):
+
+```
+# The rule targets all args
+rule 942100 (severity: critical) {
+  when request.args |> detect_sqli()
+  then block
+}
+
+# User excludes a specific key in their customization file
+exclude rule 942100 target request.args["passwd"]
+```
+
+This separates the rule definition (what to detect) from deployment customization (which
+fields to skip), matching how CRS already works in practice.
 
 ### Count as a Function
 
@@ -152,7 +169,7 @@ count(tx.crs_setup_version)    # returns Int
 3. **Bidirectional mapping** — for SecLang import and YAML v1 compat:
    - `REQUEST_HEADERS:Content-Type` -> `request.headers["Content-Type"]`
    - `&TX:score` -> `count(tx.score)`
-   - `!ARGS:foo` -> `request.args[!"foo"]`
+   - `!ARGS:foo` -> target exclusion via ADR-0006: `exclude rule ... target request.args["foo"]`
 
 4. **YAML v2 syntax** (intermediate, before Phase 5 text syntax):
 
@@ -192,7 +209,8 @@ completion.
 - Type checking becomes possible
 - Shorter, more readable conditions
 - Natural path to function composition (Phase 2)
-- Bracket notation handles map access, exclusions, and regex selectors uniformly
+- Bracket notation handles map key access cleanly
+- Target exclusions separated from rule definitions (ADR-0006)
 
 ### Negative
 

--- a/docs/adr/0001-typed-field-namespace.md
+++ b/docs/adr/0001-typed-field-namespace.md
@@ -41,8 +41,12 @@ Fields use a hierarchical dot-separated namespace:
 request.method          # was: REQUEST_METHOD
 request.uri             # was: REQUEST_URI
 request.uri.path        # was: REQUEST_URI (path component)
+request.filename        # was: REQUEST_FILENAME
+request.basename        # was: REQUEST_BASENAME
+request.line            # was: REQUEST_LINE
 request.protocol        # was: REQUEST_PROTOCOL
 request.body            # was: REQUEST_BODY
+request.body.length     # was: REQUEST_BODY_LENGTH
 request.headers         # was: REQUEST_HEADERS (entire map)
 request.headers["Host"] # was: REQUEST_HEADERS:Host
 request.cookies         # was: REQUEST_COOKIES (entire map)
@@ -53,8 +57,10 @@ request.args.post       # was: ARGS_POST
 request.args["id"]      # was: ARGS:id
 
 response.status         # was: RESPONSE_STATUS
+response.protocol       # was: RESPONSE_PROTOCOL
 response.body           # was: RESPONSE_BODY
 response.headers        # was: RESPONSE_HEADERS
+response.content_type   # was: RESPONSE_CONTENT_TYPE
 
 client.ip               # was: REMOTE_ADDR
 client.port             # was: REMOTE_PORT
@@ -68,8 +74,13 @@ matched.var             # was: MATCHED_VAR
 matched.var_name        # was: MATCHED_VAR_NAME
 matched.vars            # was: MATCHED_VARS (map)
 
+files.names             # was: FILES_NAMES
+files.sizes             # was: FILES_SIZES
+files.tmpnames          # was: FILES_TMPNAMES
+
 multipart.filename      # was: MULTIPART_FILENAME
 multipart.name          # was: MULTIPART_NAME
+multipart.part_headers  # was: MULTIPART_PART_HEADERS
 
 time.epoch              # was: TIME_EPOCH
 time.year               # was: TIME_YEAR

--- a/docs/adr/0002-pipeline-operator.md
+++ b/docs/adr/0002-pipeline-operator.md
@@ -178,8 +178,8 @@ type FunctionCall struct {
 ### YAML v2 Representation (intermediate)
 
 ```yaml
-conditions:
-  - pipeline:
+when:
+  pipeline:
       field: request.headers["User-Agent"]
       steps:
         - fn: url_decode

--- a/docs/adr/0002-pipeline-operator.md
+++ b/docs/adr/0002-pipeline-operator.md
@@ -1,0 +1,251 @@
+# ADR-0002: Pipeline Operator for Composition
+
+- **Status:** Proposed
+- **Date:** 2026-04-13
+- **Phase:** 3 (conditional — applies only if ADR-0009 chooses custom parser)
+
+## Context
+
+CRSLang currently separates transformations from operators. A condition applies an
+ordered list of transformations to the target value, then tests the result with a single
+operator:
+
+```yaml
+conditions:
+  - collections:
+      - name: REQUEST_HEADERS
+        arguments: [User-Agent]
+    transformations:
+      - urlDecode
+      - lowercase
+      - removeWhitespace
+    operator:
+      name: rx
+      value: "malicious-pattern"
+```
+
+This model has limitations:
+
+1. **Transformations and operators are disconnected** — they sit in separate YAML
+   sections even though they form a logical pipeline.
+2. **No intermediate branching** — you cannot apply different operators to different
+   transformation stages of the same field.
+3. **Operators are special** — they have different syntax from transformations despite
+   being conceptually similar (functions that take input and produce output).
+4. **No composition** — you cannot nest or combine transformation results.
+
+## Decision
+
+Introduce a **pipeline operator** (`|>`) that chains functions left-to-right. Both
+transformations and operators become functions connected by the pipeline.
+
+### Syntax
+
+```
+field |> transform1() |> transform2() |> predicate("pattern")
+```
+
+The pipeline reads left-to-right:
+1. Start with a field reference (from ADR-0001)
+2. Each `|>` passes the output of the left side as the first argument to the right side
+3. Intermediate functions (transformations) return the transformed value
+4. Terminal functions (operators/predicates) return `bool`
+
+### Examples
+
+**Simple match:**
+```
+request.uri |> matches("^/admin")
+```
+
+**Transformation chain:**
+```
+request.headers["User-Agent"]
+  |> url_decode()
+  |> lowercase()
+  |> remove_whitespace()
+  |> matches("malicious-pattern")
+```
+
+**Negation:**
+```
+not(request.headers["Content-Length"] |> matches("^0?$"))
+```
+
+**Count:**
+```
+count(tx.crs_setup_version) |> eq(0)
+```
+
+**IP matching:**
+```
+client.ip |> ip_in_range("10.0.0.0/8", "172.16.0.0/12")
+```
+
+### Function Categories
+
+#### Transformation Functions (return transformed value)
+
+| Function | Input -> Output | SecLang equivalent |
+|----------|-----------------|-------------------|
+| `lowercase()` | String -> String | `t:lowercase` |
+| `uppercase()` | String -> String | `t:uppercase` |
+| `url_decode()` | String -> String | `t:urlDecode` |
+| `url_decode_uni()` | String -> String | `t:urlDecodeUni` |
+| `html_entity_decode()` | String -> String | `t:htmlEntityDecode` |
+| `js_decode()` | String -> String | `t:jsDecode` |
+| `css_decode()` | String -> String | `t:cssDecode` |
+| `base64_decode()` | String -> String | `t:base64Decode` |
+| `hex_decode()` | String -> String | `t:hexDecode` |
+| `compress_whitespace()` | String -> String | `t:compressWhitespace` |
+| `remove_whitespace()` | String -> String | `t:removeWhitespace` |
+| `remove_nulls()` | String -> String | `t:removeNulls` |
+| `remove_comments()` | String -> String | `t:removeComments` |
+| `normalize_path()` | String -> String | `t:normalisePath` |
+| `normalize_path_win()` | String -> String | `t:normalisePathWin` |
+| `cmd_line()` | String -> String | `t:cmdLine` |
+| `sql_hex_decode()` | String -> String | `t:sqlHexDecode` |
+| `escape_seq_decode()` | String -> String | `t:escapeSeqDecode` |
+| `trim()` | String -> String | `t:trim` |
+| `length()` | String -> Int | `t:length` |
+| `md5()` | String -> String | `t:md5` |
+| `sha1()` | String -> String | `t:sha1` |
+
+#### Predicate Functions (return bool)
+
+| Function | Input Type | SecLang equivalent |
+|----------|------------|-------------------|
+| `matches(pattern)` | String -> Bool | `@rx` |
+| `matches_global(pattern)` | String -> Bool | `@rxGlobal` |
+| `eq(value)` | String/Int -> Bool | `@eq` / `@streq` |
+| `gt(value)` | Int -> Bool | `@gt` |
+| `ge(value)` | Int -> Bool | `@ge` |
+| `lt(value)` | Int -> Bool | `@lt` |
+| `le(value)` | Int -> Bool | `@le` |
+| `contains(value)` | String -> Bool | `@contains` |
+| `contains_word(values...)` | String -> Bool | `@pm` |
+| `contains_word_from_file(path)` | String -> Bool | `@pmFromFile` |
+| `begins_with(value)` | String -> Bool | `@beginsWith` |
+| `ends_with(value)` | String -> Bool | `@endsWith` |
+| `within(value)` | String -> Bool | `@within` |
+| `ip_in_range(ranges...)` | IP -> Bool | `@ipMatch` |
+| `ip_in_range_from_file(path)` | IP -> Bool | `@ipMatchFromFile` |
+| `detect_sqli()` | String -> Bool | `@detectSQLi` |
+| `detect_xss()` | String -> Bool | `@detectXSS` |
+| `validate_byte_range(range)` | Bytes -> Bool | `@validateByteRange` |
+| `validate_url_encoding()` | String -> Bool | `@validateUrlEncoding` |
+| `validate_utf8()` | String -> Bool | `@validateUtf8Encoding` |
+| `verify_cc(pattern)` | String -> Bool | `@verifyCC` |
+| `rbl(server)` | IP -> Bool | `@rbl` |
+| `geo_lookup()` | IP -> Bool | `@geoLookup` |
+
+### Type Checking
+
+The pipeline enables static type checking:
+
+```
+# Valid: String -> String -> String -> Bool
+request.uri |> lowercase() |> url_decode() |> matches("pattern")
+
+# Invalid: Int -> String (type error)
+response.status |> lowercase()
+
+# Valid: String -> Int -> Bool
+request.headers["Content-Length"] |> length() |> gt(100)
+```
+
+Type errors are caught at parse time with clear messages:
+```
+Error: lowercase() expects String input, got Int from 'response.status'
+```
+
+### IR Representation
+
+```go
+type Pipeline struct {
+    Source  FieldRef       // Starting field
+    Steps   []FunctionCall // Ordered transformation/predicate calls
+    Negated bool           // Wrapping not()
+}
+
+type FunctionCall struct {
+    Name      string       // "lowercase", "matches", etc.
+    Arguments []Value      // Function arguments (patterns, numbers, etc.)
+    ReturnType FieldType   // Computed from function signature
+}
+```
+
+### YAML v2 Representation (intermediate)
+
+```yaml
+conditions:
+  - pipeline:
+      field: request.headers["User-Agent"]
+      steps:
+        - fn: url_decode
+        - fn: lowercase
+        - fn: matches
+          args: ["malicious-pattern"]
+```
+
+## Alternatives Considered
+
+### A: Nested Function Calls (Wirefilter-style)
+
+```
+matches(lowercase(url_decode(request.headers["User-Agent"])), "pattern")
+```
+
+**Rejected because:**
+- Reads inside-out, opposite to CRS authors' mental model (they think in transform
+  chains applied left-to-right)
+- Deeply nested calls are hard to scan
+- SecLang's `t:` pipeline is already left-to-right; changing direction would confuse
+  existing users
+
+### B: Method Chaining (CEL-style)
+
+```
+request.headers["User-Agent"].urlDecode().lowercase().matches("pattern")
+```
+
+**Considered viable but:**
+- Requires fields to be objects with methods, complicating the type system
+- Dot already used for field hierarchy (ADR-0001), adding method calls on the same
+  syntax creates ambiguity: is `request.headers.names` a field or a method?
+- Less visually distinct between "accessing data" and "transforming data"
+
+### C: Unix Pipe (`|`)
+
+```
+request.uri | lowercase | matches("pattern")
+```
+
+**Rejected because:**
+- `|` is commonly used for bitwise OR or alternatives in regex context
+- Could create parsing ambiguity with future boolean OR syntax
+- `|>` is established in Elixir, F#, OCaml, and Gleam for this exact purpose
+
+## Consequences
+
+### Positive
+
+- Unified function model: transformations and operators are both "just functions"
+- Natural left-to-right reading matches CRS authors' mental model
+- Static type checking becomes possible
+- Easy to add new functions without syntax changes
+- Pipeline can be serialized to any format (YAML, text, JSON)
+
+### Negative
+
+- New syntax to learn (`|>` is not universally known)
+- Function naming must be carefully designed — once published, names are hard to change
+- Some SecLang operators don't fit the function model cleanly (e.g., `@inspectFile`
+  which is really a side-effect)
+
+### Risks
+
+- **Function explosion** — resist adding functions for every conceivable transformation.
+  Start with the functions needed by CRS rules and grow from there.
+- **Performance implications** — pipeline representation must compile efficiently to
+  target engines. Ensure the IR preserves enough information for backends to optimize.

--- a/docs/adr/0002-pipeline-operator.md
+++ b/docs/adr/0002-pipeline-operator.md
@@ -116,8 +116,9 @@ client.ip |> ip_in_range("10.0.0.0/8", "172.16.0.0/12")
 | Function | Input Type | SecLang equivalent |
 |----------|------------|-------------------|
 | `matches(pattern)` | String -> Bool | `@rx` |
-| `matches_global(pattern)` | String -> Bool | `@rxGlobal` |
+| `capture(pattern)` | String -> Bool | `@rx` + `capture` action (matches and stores groups) |
 | `eq(value)` | String/Int -> Bool | `@eq` / `@streq` |
+| `unconditional()` | any -> Bool | `@unconditionalMatch` (always true) |
 | `gt(value)` | Int -> Bool | `@gt` |
 | `ge(value)` | Int -> Bool | `@ge` |
 | `lt(value)` | Int -> Bool | `@lt` |

--- a/docs/adr/0002-pipeline-operator.md
+++ b/docs/adr/0002-pipeline-operator.md
@@ -124,12 +124,12 @@ client.ip |> ip_in_range("10.0.0.0/8", "172.16.0.0/12")
 | `le(value)` | Int -> Bool | `@le` |
 | `contains(value)` | String -> Bool | `@contains` |
 | `contains_word(values...)` | String -> Bool | `@pm` |
-| `contains_word_from_file(path)` | String -> Bool | `@pmFromFile` |
+| `contains_word_from_file(path)` | String -> Bool | `@pmFromFile` (external word lists) |
 | `begins_with(value)` | String -> Bool | `@beginsWith` |
 | `ends_with(value)` | String -> Bool | `@endsWith` |
 | `within(value)` | String -> Bool | `@within` |
 | `ip_in_range(ranges...)` | IP -> Bool | `@ipMatch` |
-| `ip_in_range_from_file(path)` | IP -> Bool | `@ipMatchFromFile` |
+| `ip_in_range_from_file(path)` | IP -> Bool | `@ipMatchFromFile` (external IP lists) |
 | `detect_sqli()` | String -> Bool | `@detectSQLi` |
 | `detect_xss()` | String -> Bool | `@detectXSS` |
 | `validate_byte_range(range)` | Bytes -> Bool | `@validateByteRange` |
@@ -249,3 +249,22 @@ request.uri | lowercase | matches("pattern")
   Start with the functions needed by CRS rules and grow from there.
 - **Performance implications** — pipeline representation must compile efficiently to
   target engines. Ensure the IR preserves enough information for backends to optimize.
+
+### Notes on File-Based Functions and Regex Assembly
+
+**Regex patterns** from `crs-toolchain` regex assembly (`.ra` files) are **inlined** at
+build time. The toolchain compiles them into optimized patterns before CRSLang sees them.
+There is no `matches_from_file()` — the final regex is embedded in the rule.
+
+**Pattern match word lists** (`@pmFromFile`) and **IP range lists** (`@ipMatchFromFile`)
+remain as external file references via `contains_word_from_file(path)` and
+`ip_in_range_from_file(path)`. These lists can be thousands of entries and are data, not
+logic — inlining them would make rules unreadable.
+
+### The `t:none` Convention
+
+SecLang's `t:none` transformation (which resets default transformations from
+`SecDefaultAction`) has no equivalent in CRSLang and is not needed. Each rule explicitly
+states its transforms via the pipeline or named macros, and the `defaults {}` block
+(ADR-0008) does not inject hidden transformation chains. The problem `t:none` solved
+does not exist in the new model.

--- a/docs/adr/0002-pipeline-operator.md
+++ b/docs/adr/0002-pipeline-operator.md
@@ -196,12 +196,27 @@ when:
 matches(lowercase(url_decode(request.headers["User-Agent"])), "pattern")
 ```
 
-**Rejected because:**
-- Reads inside-out, opposite to CRS authors' mental model (they think in transform
-  chains applied left-to-right)
-- Deeply nested calls are hard to scan
-- SecLang's `t:` pipeline is already left-to-right; changing direction would confuse
-  existing users
+**Viable with macros (see ADR-0009).** The original concern about deep nesting dissolves
+when named composition functions keep calls at 1-2 levels:
+
+```
+# Without macros: 4 levels deep, hard to read
+matches(lowercase(url_decode(js_decode(request.args))), "pattern")
+
+# With macros: readable
+detect_sqli(normalize(request.args))
+```
+
+If HCL is chosen as the language base (ADR-0009 Option A), nested function calls are the
+only available syntax — HCL's grammar cannot be extended with `|>`. In that path, macros
+are essential to keep conditions readable.
+
+**Trade-offs vs pipeline:**
+- Reads inside-out for ad-hoc chains (without macros), which is opposite to CRS authors'
+  mental model from SecLang's left-to-right `t:` chains
+- With macros as the steady state, the reading direction difference is minimal
+- `&&`/`||` boolean operators (HCL) are more familiar to developers than `and`/`or`
+  keywords, but less readable for security engineers
 
 ### B: Method Chaining (CEL-style)
 

--- a/docs/adr/0003-boolean-algebra.md
+++ b/docs/adr/0003-boolean-algebra.md
@@ -1,0 +1,495 @@
+# ADR-0003: Boolean Algebra Replacing Chains
+
+- **Status:** Proposed
+- **Date:** 2026-04-13
+- **Phase:** 2
+
+## Context
+
+SecLang uses the `chain` action to create AND logic between rules. When a rule has a
+`chain` action, the next rule in sequence becomes a chained condition — the second rule
+only evaluates if the first matches. This is how SecLang expresses multi-condition logic:
+
+```
+SecRule REQUEST_METHOD "@rx ^(?:GET|HEAD)$" \
+    "id:920170,phase:1,block,chain"
+    SecRule REQUEST_HEADERS:Content-Length "!@rx ^0?$" \
+        "setvar:'tx.anomaly_score=+5'"
+```
+
+CRSLang v1 models this directly:
+
+```yaml
+kind: rule
+metadata:
+  id: 920170
+conditions:
+  - variables: [REQUEST_METHOD]
+    operator: {name: rx, value: "^(?:GET|HEAD)$"}
+actions:
+  disruptive: {action: block}
+  flow: [chain]
+chainedRule:
+  kind: rule
+  conditions:
+    - collections:
+        - name: REQUEST_HEADERS
+          arguments: [Content-Length]
+      operator: {negate: true, name: rx, value: "^0?$"}
+  actions:
+    non-disruptive:
+      - action: setvar
+        param: "tx.anomaly_score=+5"
+```
+
+### Problems with chains
+
+1. **Only AND** — chains can only express AND. There is no native OR at the condition
+   level (only multiple variables in a single `SecRule`, which is a limited form of OR).
+2. **Sequential nesting** — deeply chained rules are hard to read and maintain. A 4-way
+   AND requires 3 levels of nesting.
+3. **Side-effects at intermediate links** — chained rules can have their own
+   transformations, actions (setvar, log), and even different targets. This conflates
+   "condition" with "intermediate action."
+4. **Fragile ordering** — the chain is positional. Inserting a rule between chain links
+   breaks the logic.
+5. **No grouping** — you cannot express `(A AND B) OR (C AND D)` in SecLang. CRS works
+   around this with separate rules and anomaly scoring.
+
+## Decision
+
+Replace chains with **explicit boolean algebra**: `and`, `or`, `not`, with parenthesized
+grouping.
+
+### Syntax
+
+```
+rule 920170 (phase: request) {
+  when request.method |> matches("^(?:GET|HEAD)$")
+   and request.headers["Content-Length"] |> not(matches("^0?$"))
+  then block {
+    tx.anomaly_score += 5
+  }
+}
+```
+
+### Operator Precedence
+
+From highest to lowest:
+1. `not` (unary)
+2. `and`
+3. `or`
+
+Parentheses override precedence:
+
+```
+when (A or B) and (C or D)
+```
+
+### Expression Tree IR
+
+```go
+type Expr interface {
+    exprNode()
+}
+
+type AndExpr struct {
+    Left  Expr
+    Right Expr
+}
+
+type OrExpr struct {
+    Left  Expr
+    Right Expr
+}
+
+type NotExpr struct {
+    Inner Expr
+}
+
+type PredicateExpr struct {
+    Pipeline Pipeline  // from ADR-0002
+}
+```
+
+A rule has exactly one `Expr` as its condition:
+
+```go
+type Rule struct {
+    ID       int
+    Metadata RuleMetadata
+    When     Expr           // single expression tree
+    Then     ActionBlock    // from ADR-0004
+}
+```
+
+### Handling Chain Side-Effects
+
+#### Current Semantics in CRSLang v1
+
+The existing normalizer (`types/condition_directives.go:117-128`) reveals how CRSLang
+already handles chains:
+
+- **Chain links without non-disruptive actions** are **flattened** — their conditions are
+  merged into a single AND group with the next link.
+- **Chain links with non-disruptive actions** (setvar, capture, ctl, etc.) are **kept as
+  separate `ChainedRule` nodes** — preserving the side-effect boundary.
+
+This means the IR already distinguishes between "pure condition" chain links and "chain
+links with side-effects." The boolean algebra model must account for both.
+
+#### Analysis of CRS Chain Patterns
+
+An audit of real CRS rules reveals three categories of intermediate chain side-effects:
+
+**Category 1: `capture` on the first link (used by the final link)**
+
+CRS rule 920190 (`REQUEST-920-PROTOCOL-ENFORCEMENT.conf`) uses `capture` on the first
+link to extract regex groups, which are then referenced by the chained link's actions:
+
+```
+SecRule REQUEST_HEADERS:Range "@rx (\d+)-(\d+)" \
+    "id:920190,phase:1,block,capture,chain"
+    SecRule REQUEST_METHOD "@streq GET" \
+        "setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+```
+
+Here `capture` must execute when the first condition matches (not when the full chain
+matches), because captured groups are consumed downstream. However, the captured values
+are only *useful* if the full chain matches. In the boolean model, `capture()` becomes a
+pipeline function that extracts groups as a side-effect of matching:
+
+```
+when request.headers["Range"] |> capture("(\\d+)-(\\d+)")
+ and request.method |> eq("GET")
+then block { tx.inbound_anomaly_score_pl1 += tx.critical_anomaly_score }
+```
+
+The `capture()` function both tests the regex and stores the match groups. It is a
+predicate with a side-effect — similar to how `matches()` works, but additionally
+populating the match context.
+
+**Category 2: `ctl` on intermediate links (engine configuration)**
+
+CRS rule 905111 (`testdata/test_36_chain.conf`) uses `ctl:ruleRemoveByTag` on an
+intermediate link in a 3-level chain:
+
+```
+SecRule REMOTE_ADDR "@ipMatch 127.0.0.1,::1" \
+    "id:905111,phase:1,pass,chain"
+    SecRule REQUEST_HEADERS:User-Agent "@endsWith (internal dummy connection)" \
+        "ctl:ruleRemoveByTag=TEST_CHAIN,chain"
+        SecRule REQUEST_LINE "@rx ^(?:GET /|OPTIONS \*) HTTP/[12]\.[01]$" \
+            "ctl:ruleRemoveByTag=OWASP_CRS,ctl:auditEngine=Off"
+```
+
+The intermediate `ctl` modifies engine state only if that specific link matches. In
+ModSecurity, `ctl` actions on chain links execute per-link, not deferred to full-chain
+match. This is the hardest pattern to model in a pure boolean expression.
+
+**Category 3: `setvar` on the first link (consumed by a later link)**
+
+CRS rule 901320 (`REQUEST-901-INITIALIZATION.conf`) sets a TX variable on the first link,
+then the final link uses that variable in a transformation:
+
+```
+SecRule &TX:ENABLE_DEFAULT_COLLECTIONS "@eq 1" \
+    "id:901320,phase:1,pass,nolog,\
+    setvar:'tx.ua_hash=%{REQUEST_HEADERS.User-Agent}',chain"
+    SecRule TX:ENABLE_DEFAULT_COLLECTIONS "@eq 1" \
+        "chain"
+        SecRule TX:ua_hash "@unconditionalMatch" \
+            "t:none,t:sha1,t:hexEncode,\
+            initcol:global=global,\
+            initcol:ip=%{remote_addr}_%{MATCHED_VAR}"
+```
+
+Here, `setvar` on link 1 creates `tx.ua_hash`, and link 3 reads it. The side-effect
+must execute before the downstream link evaluates. This is fundamentally a **data-flow
+dependency between conditions**, not just a side-effect.
+
+#### Design Options
+
+**Option A: Side-effects only on the rule (move to `then` block)**
+
+All setvar/log/ctl actions move to the `then` block and execute only when the full
+expression matches.
+
+```
+rule 920190 (phase: request) {
+  when request.headers["Range"] |> matches("(\\d+)-(\\d+)")
+   and request.method |> eq("GET")
+  then block {
+    capture()
+    tx.inbound_anomaly_score_pl1 += tx.critical_anomaly_score
+  }
+}
+```
+
+- Works for **most** CRS rules (the majority of chains have side-effects only on the
+  final link).
+- **Breaks Category 2** (intermediate `ctl`): if `ctl` is deferred, the engine
+  configuration change happens too late.
+- **Breaks Category 3** (data-flow `setvar`): if `setvar` moves to `then`, the
+  downstream condition cannot read the variable.
+
+**Option B: Conditional side-effects on sub-expressions**
+
+Allow inline effect blocks on individual predicates:
+
+```
+rule 905111 (phase: request) {
+  when client.ip |> ip_in_range("127.0.0.1", "::1")
+   and request.headers["User-Agent"] |> ends_with("(internal dummy connection)") {
+         configure(rule_remove_by_tag: "TEST_CHAIN")
+       }
+   and request.line |> matches("^(?:GET /|OPTIONS \\*) HTTP/[12]\\.[01]$") {
+         configure(rule_remove_by_tag: "OWASP_CRS", audit_engine: off)
+       }
+  then pass
+}
+```
+
+- Handles all three categories.
+- Adds complexity: the reader must understand that `{ ... }` after a predicate is a
+  conditional side-effect, not part of the boolean expression.
+- Requires defining execution semantics precisely (see below).
+
+**Option C: `let` bindings for data-flow dependencies**
+
+Introduce variable bindings to handle Category 3 without inline side-effects:
+
+```
+rule 901320 (phase: request) {
+  let ua_hash = request.headers["User-Agent"] |> sha1() |> hex_encode()
+  when count(tx.enable_default_collections) |> eq(1)
+   and tx.enable_default_collections |> eq(1)
+  then pass {
+    init_collection(global: "global")
+    init_collection(ip: client.ip + "_" + ua_hash)
+  }
+}
+```
+
+- Separates data flow from conditions cleanly.
+- `let` bindings are evaluated eagerly, before the `when` clause.
+- Handles Category 3 without inline side-effects.
+- Does not address Category 2 (`ctl` on intermediate links).
+
+#### Recommendation
+
+Use a **layered approach**:
+
+1. **Phase 3a** — implement Option A (side-effects in `then` only). This handles the
+   vast majority of CRS rules. Chain links without intermediate side-effects are already
+   flattened by the existing normalizer, so this is the natural starting point.
+
+2. **Phase 3b** — add `let` bindings (Option C) for data-flow dependencies. This
+   cleanly handles Category 3 without complicating the boolean expression model.
+
+3. **Phase 3c** — if Category 2 (`ctl` on intermediate links) proves common enough to
+   warrant language support, add conditional side-effects (Option B) as an extension.
+   Before doing so, audit whether these `ctl` patterns can be restructured as separate
+   rules instead.
+
+#### Execution Semantics (if Option B is adopted)
+
+If conditional side-effects are added:
+- Side-effects on a predicate execute **when that predicate evaluates to true** during
+  expression evaluation.
+- Evaluation order is **left-to-right** with **short-circuit**: `A and B` does not
+  evaluate `B` if `A` is false; `A or B` does not evaluate `B` if `A` is true.
+- Side-effects from predicates that are not evaluated (due to short-circuit) do **not**
+  execute.
+- This matches ModSecurity's chain behavior where a chain link's actions only fire if
+  that link matches.
+
+### Migration from Chains
+
+The conversion is mechanical for most cases:
+
+```
+# Chain of depth N (no intermediate side-effects):
+rule + chain -> chained1 + chain -> chained2
+# Becomes:
+when condition1 and condition2 and condition3
+
+# Negated chain link:
+rule + chain -> (negated operator in chained rule)
+# Becomes:
+when condition1 and not(condition2)
+```
+
+For chains with intermediate side-effects, by category:
+
+**Category 1 (`capture`):** Model as a pipeline function. `capture()` replaces both the
+`@rx` operator and the `capture` action — it matches and extracts in one step:
+
+```
+# SecLang:
+SecRule REQUEST_HEADERS:Range "@rx (\d+)-(\d+)" "capture,chain"
+# CRSLang:
+when request.headers["Range"] |> capture("(\\d+)-(\\d+)") and ...
+```
+
+**Category 2 (`ctl` on intermediate links):** Restructure as separate rules where
+possible. If not possible and Option B is adopted, use conditional side-effects:
+
+```
+# SecLang:
+SecRule REMOTE_ADDR "@ipMatch 127.0.0.1" "chain"
+    SecRule REQUEST_HEADERS:User-Agent "@endsWith foo" "ctl:ruleRemoveByTag=X,chain"
+# CRSLang (Option B):
+when client.ip |> ip_in_range("127.0.0.1")
+ and request.headers["User-Agent"] |> ends_with("foo") {
+       configure(rule_remove_by_tag: "X")
+     }
+ and ...
+```
+
+**Category 3 (`setvar` consumed downstream):** Use `let` bindings:
+
+```
+# SecLang:
+SecRule &TX:ENABLE "@eq 1" "setvar:'tx.ua_hash=%{REQUEST_HEADERS.User-Agent}',chain"
+    SecRule TX:ua_hash "@unconditionalMatch" "t:sha1,t:hexEncode,initcol:ip=..."
+# CRSLang:
+let ua_hash = request.headers["User-Agent"] |> sha1() |> hex_encode()
+when count(tx.enable) |> eq(1) ...
+then pass { init_collection(ip: client.ip + "_" + ua_hash) }
+```
+
+### New Capabilities
+
+Boolean algebra enables patterns that are impossible or awkward in SecLang:
+
+```
+# OR conditions (currently requires separate rules + scoring)
+rule 100001 (phase: request) {
+  when request.uri |> matches("/admin")
+   and (client.ip |> ip_in_range("10.0.0.0/8")
+        or request.headers["X-Internal"] |> eq("true"))
+  then pass
+}
+
+# Complex grouping
+rule 100002 (phase: request) {
+  when (request.method |> eq("POST") or request.method |> eq("PUT"))
+   and not(request.headers["Content-Type"] |> contains("application/json"))
+   and request.body |> length() |> gt(0)
+  then block
+}
+```
+
+### YAML v2 Representation
+
+```yaml
+kind: rule
+metadata:
+  id: 920170
+  phase: request
+when:
+  and:
+    - pipeline:
+        field: request.method
+        steps:
+          - fn: matches
+            args: ["^(?:GET|HEAD)$"]
+    - not:
+        pipeline:
+          field: request.headers["Content-Length"]
+          steps:
+            - fn: matches
+              args: ["^0?$"]
+then:
+  action: block
+  effects:
+    - set: tx.anomaly_score
+      op: "+="
+      value: 5
+```
+
+## Alternatives Considered
+
+### A: Keep chains, add OR
+
+Add `or_chain` alongside `chain` to keep the sequential model but add OR support.
+
+**Rejected because:**
+- Does not address nesting depth problem
+- Creates a hybrid model that is harder to reason about than either pure chains or
+  pure boolean algebra
+- Still positional/fragile
+
+### B: Implicit AND (Rego-style)
+
+Multiple conditions in a block are implicitly ANDed:
+
+```
+rule 920170 {
+  request.method |> matches("^(?:GET|HEAD)$")
+  request.headers["Content-Length"] |> not(matches("^0?$"))
+  -> block { ... }
+}
+```
+
+**Rejected because:**
+- Implicit AND with no explicit OR creates the same asymmetry as SecLang
+- Harder to parse: where does one condition end and the next begin?
+- Less familiar to the target audience
+
+### C: Pattern Matching
+
+```
+match request {
+  method: /^(?:GET|HEAD)$/,
+  headers["Content-Length"]: not(/^0?$/)
+} -> block
+```
+
+**Rejected because:**
+- Only works for AND conditions on the same request
+- Cannot express cross-category conditions (request + response + tx)
+- Novel syntax with no established precedent
+
+## Consequences
+
+### Positive
+
+- Full boolean expressiveness: AND, OR, NOT with arbitrary nesting
+- Eliminates chain complexity and positional fragility
+- Rules become self-contained: no hidden dependencies on adjacent rules
+- Enables optimizations: expression tree can be reordered, short-circuited
+- Closer to how security engineers think about conditions
+
+### Negative
+
+- Three categories of intermediate side-effects require a layered migration (Phase 3a/b/c)
+  rather than a single clean cutover
+- `let` bindings (Phase 3b) add a new language concept not present in SecLang
+- Conditional side-effects (Phase 3c, if adopted) complicate the expression model and
+  require precise execution semantics
+- Some deeply chained rules may become long single expressions (mitigated by
+  line breaks and formatting conventions)
+
+### Risks
+
+- **Side-effect ordering** — if Option B (conditional side-effects) is adopted, the
+  semantics of short-circuit evaluation must be precisely defined: side-effects on
+  unevaluated predicates do not fire. This matches ModSecurity chain behavior but must
+  be documented and tested.
+- **Engine mapping** — not all WAF engines support full boolean algebra natively. The
+  compiler may need to decompose expressions back into chains for some targets
+  (ModSecurity, Coraza). This is a compiler concern, not a language concern.
+- **Category 2 prevalence** — intermediate `ctl` actions (Category 2) are rare in CRS
+  (found primarily in initialization and internal-traffic rules like 905111). If they
+  prove confined to a small set of rules, they can be handled by restructuring those
+  rules rather than adding Option B to the language. A full CRS audit should quantify
+  this before committing to Phase 3c.
+- **Category 3 data flow** — `let` bindings change CRSLang from a purely declarative
+  rule language to one with local variable scoping. This is a significant conceptual
+  shift. The alternative is to require these patterns to be split into multiple rules
+  with explicit TX variables, which is closer to how CRS already works.
+- **Migration correctness** — automated chain-to-boolean conversion must be validated
+  against the full CRS test suite. The three categories need separate migration paths
+  in the converter tool.

--- a/docs/adr/0003-boolean-algebra.md
+++ b/docs/adr/0003-boolean-algebra.md
@@ -280,14 +280,14 @@ rule 901320 (phase: request) {
 
 Use a **layered approach**:
 
-1. **Phase 3a** — implement Option A (side-effects in `then` only). This handles the
+1. **Phase 2a** — implement Option A (side-effects in `then` only). This handles the
    vast majority of CRS rules. Chain links without intermediate side-effects are already
    flattened by the existing normalizer, so this is the natural starting point.
 
-2. **Phase 3b** — add `let` bindings (Option C) for data-flow dependencies. This
+2. **Phase 2b** — add `let` bindings (Option C) for data-flow dependencies. This
    cleanly handles Category 3 without complicating the boolean expression model.
 
-3. **Phase 3c** — if Category 2 (`ctl` on intermediate links) proves common enough to
+3. **Phase 2c** — if Category 2 (`ctl` on intermediate links) proves common enough to
    warrant language support, add conditional side-effects (Option B) as an extension.
    Before doing so, audit whether these `ctl` patterns can be restructured as separate
    rules instead.
@@ -358,6 +358,56 @@ let ua_hash = request.headers["User-Agent"] |> sha1() |> hex_encode()
 when count(tx.enable) |> eq(1) ...
 then pass { init_collection(ip: client.ip + "_" + ua_hash) }
 ```
+
+### Collection Quantifier: `each()`
+
+SecLang's `multiMatch` action changes how a collection-targeting condition evaluates —
+instead of stopping at the first match, it iterates all values and fires side-effects
+per match. This is currently modeled as a non-disruptive action, but it is semantically
+a condition quantifier.
+
+**Recommendation: `each()` as a condition-level quantifier (Option A).**
+
+```
+# Without each(): first match wins, effects fire once
+when request.args |> detect_sqli()
+
+# With each(): all values tested, effects fire per match
+when each(request.args) |> detect_sqli()
+then block {
+  tx.sqli_score += 5     # incremented per matching argument
+  log(data: matched.var)  # logged per matching argument
+}
+```
+
+`each()` wraps a map-typed field and signals "iterate all values." Without it, the
+default is first-match semantics.
+
+**Alternatives documented:**
+
+- **Option B: Effect-level modifier** — `then block (per_match: true) { ... }`. Simpler
+  to parse but misleading: the reader assumes first-match from the condition until
+  they notice the modifier.
+- **Option C: Separate iteration block** — `for each match { per-match effects } then
+  block { once-only effects }`. Most expressive (supports both per-match and once-only
+  effects) but adds a new block type.
+- **Option D: Drop it** — if scoring becomes first-class (ADR-0011), per-match scoring
+  may be handled at the scoring level rather than as a language construct.
+
+`multiMatch` is rarely used in CRS, so Option A is sufficient for the foreseeable
+future. Options B/C can be revisited if use cases emerge.
+
+### String Interpolation
+
+SecLang uses `%{TX:score}` and `%{MATCHED_VAR}` for string interpolation in actions
+(`logdata`, `msg`, `setvar`). Most of these cases become direct field references or
+expressions in CRSLang (e.g., `log(data: matched.var)`).
+
+For cases that require composed strings (log messages, dynamic values), CRSLang needs
+a string construction mechanism. The exact form — string interpolation
+(`"Score: ${tx.anomaly_score}"`), concatenation (`"Score: " + string(tx.score)`), or
+a format function (`format("Score: %d", tx.score)`) — is deferred to the effects model
+design in Phase 3. The IR must support composed string values in effect arguments.
 
 ### New Capabilities
 
@@ -464,10 +514,10 @@ match request {
 
 ### Negative
 
-- Three categories of intermediate side-effects require a layered migration (Phase 3a/b/c)
+- Three categories of intermediate side-effects require a layered migration (Phase 2a/b/c)
   rather than a single clean cutover
-- `let` bindings (Phase 3b) add a new language concept not present in SecLang
-- Conditional side-effects (Phase 3c, if adopted) complicate the expression model and
+- `let` bindings (Phase 2b) add a new language concept not present in SecLang
+- Conditional side-effects (Phase 2c, if adopted) complicate the expression model and
   require precise execution semantics
 - Some deeply chained rules may become long single expressions (mitigated by
   line breaks and formatting conventions)
@@ -485,7 +535,7 @@ match request {
   (found primarily in initialization and internal-traffic rules like 905111). If they
   prove confined to a small set of rules, they can be handled by restructuring those
   rules rather than adding Option B to the language. A full CRS audit should quantify
-  this before committing to Phase 3c.
+  this before committing to Phase 2c.
 - **Category 3 data flow** — `let` bindings change CRSLang from a purely declarative
   rule language to one with local variable scoping. This is a significant conceptual
   shift. The alternative is to require these patterns to be split into multiple rules

--- a/docs/adr/0004-structured-actions.md
+++ b/docs/adr/0004-structured-actions.md
@@ -221,17 +221,29 @@ then:
 ### Flow Actions
 
 - **`chain`** — eliminated entirely (ADR-0003)
-- **`skip`/`skipAfter`** — replaced by rule ordering and labels:
+- **`skip`/`skipAfter`/`SecMarker`** — eliminated entirely. These were an
+  implementation detail of ModSecurity's sequential evaluation model. The actual intent
+  is **conditional rule activation** — "only run these rules if condition X holds."
+
+  This is now expressed as **guarded groups** (ADR-0006):
 
   ```
-  # was: skipAfter:END_RULE_GROUP
-  goto END_RULE_GROUP     # or: skip to END_RULE_GROUP
+  # was: SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" "skipAfter:END-941"
+  #      ... rules ...
+  #      SecMarker "END-941"
 
-  label END_RULE_GROUP    # was: SecMarker:END_RULE_GROUP
+  group "xss_pl2" (requires: paranoia >= 2) {
+    rule 941120 (severity: critical) { ... }
+    rule 941130 (severity: critical) { ... }
+  }
   ```
 
-  Note: `skip`/`skipAfter` are rare in CRS and primarily used for backwards
-  compatibility. Consider deprecating in favor of explicit rule grouping (Phase 6).
+  The compiler generates the appropriate `skipAfter`/`SecMarker` pairs when compiling
+  to SecLang. For paranoia-level gating specifically, the `paranoia` attribute on rules
+  (ADR-0011) allows the compiler to group and gate rules automatically.
+
+  No `skip_to()`, `goto`, or `label` exists in CRSLang. The language expresses intent
+  (conditional activation), not mechanism (skip/marker).
 
 ## Alternatives Considered
 

--- a/docs/adr/0004-structured-actions.md
+++ b/docs/adr/0004-structured-actions.md
@@ -88,18 +88,18 @@ Assignment operators:
 - `+=` — increment (was: `setvar:'collection.var=+value'`)
 - `-=` — decrement (was: `setvar:'collection.var=-value'`)
 
-Variable expiry:
+Variable expiry (the variable is removed after the TTL, not the value):
 
 ```
-tx.block_duration = 3600 (expires: 3600)   # was: expirevar:'tx.block_duration=3600'
+expire(tx.block_duration, 3600)   # was: expirevar:'tx.block_duration=3600'
 ```
 
 #### Logging
 
 ```
-log()                    # was: action: log
-audit_log()              # was: action: auditlog
-log(data: "%{MATCHED_VAR}")  # was: logdata:'%{MATCHED_VAR}'
+log()                       # was: action: log
+audit_log()                 # was: action: auditlog
+log(data: matched.var)      # was: logdata:'%{MATCHED_VAR}'
 ```
 
 Or combined (since most rules use both):
@@ -134,22 +134,40 @@ configure(request_body_processor: XML)
 
 ### Complete Examples
 
-**Simple block with scoring:**
+**Simple block with scoring** (severity-derived, per ADR-0011):
 ```
-rule 941100 (phase: request, severity: critical) {
-  when request.args |> js_decode() |> detect_xss()
+group "xss_detection" {
+  category = "xss"
+
+  rule 941100 (severity: critical) {
+    when request.args |> js_decode() |> capture("xss-pattern")
+    then block {
+      log(audit: true, data: matched.var)
+    }
+  }
+}
+```
+
+Scoring is automatic: `severity: critical` + `category: xss` contribute to
+`anomaly_score` and `xss_score` based on the globals scoring table. `capture()` replaces
+the separate `@rx` + `capture` action. For rules that need manual score manipulation,
+use the `score()` override or direct TX assignment:
+
+```
+rule 941100 (severity: critical) {
+  when request.args |> detect_xss()
   then block {
-    tx.xss_score += 5
-    tx.anomaly_score += 5
-    capture()
+    score(anomaly: 5, xss: 5)   # explicit override
     log(audit: true, data: matched.var)
   }
 }
 ```
 
-**Pass with configuration:**
+**Pass with configuration** (setup-style rule, kept for illustrating direct TX
+assignment; note that ADR-0011 lifts `scoring_threshold` and global paranoia settings
+out of rules into a `globals` block):
 ```
-rule 900100 (phase: request) {
+rule 900100 (phase: request_headers) {
   when true
   then pass {
     tx.paranoia_level = 1
@@ -160,7 +178,7 @@ rule 900100 (phase: request) {
 
 **Deny with status:**
 ```
-rule 901001 (phase: request, severity: critical) {
+rule 901001 (phase: request_headers, severity: critical) {
   when count(tx.crs_setup_version) |> eq(0)
   then deny(status: 500) {
     log(audit: true)

--- a/docs/adr/0004-structured-actions.md
+++ b/docs/adr/0004-structured-actions.md
@@ -1,0 +1,309 @@
+# ADR-0004: Structured Action Model
+
+- **Status:** Proposed
+- **Date:** 2026-04-13
+- **Phase:** 3
+
+## Context
+
+CRSLang v1 inherits SecLang's action model, which groups actions into four categories
+in a flat bag:
+
+```yaml
+actions:
+  disruptive:
+    action: deny
+  non-disruptive:
+    - action: log
+    - action: auditlog
+    - action: setvar
+      param: "tx.anomaly_score=+5"
+    - action: setvar
+      param: "tx.inbound_anomaly_score=+5"
+    - action: capture
+  flow:
+    - chain
+  data:
+    - action: status
+      param: "403"
+```
+
+### Problems
+
+1. **Category confusion** — the four categories (disruptive, non-disruptive, flow, data)
+   are SecLang implementation details. Rule authors think in terms of "what happens when
+   this matches," not which category an action belongs to.
+2. **setvar string parsing** — `setvar: "tx.anomaly_score=+5"` encodes a field, an
+   operation, and a value in a string that must be parsed separately.
+3. **flow actions in the action bag** — `chain` is a structural concept (ADR-0003
+   replaces it), not an action. `skip`/`skipAfter` are control flow, not side-effects.
+4. **ctl overloading** — `ctl:forceRequestBodyVariable=On` mixes engine configuration
+   with rule actions.
+5. **status as a data action** — the HTTP response status is a parameter of the
+   disruptive action, not a separate action.
+
+## Decision
+
+Replace the action bag with a **structured action block** consisting of a disruptive
+action (with parameters) and an optional block of side-effects.
+
+### Syntax
+
+```
+then <disruptive-action>(<params>) {
+  <side-effects>
+}
+```
+
+### Disruptive Actions
+
+Each disruptive action can take named parameters:
+
+```
+then deny(status: 403)
+then block(status: 403)
+then redirect(url: "https://example.com/blocked")
+then drop
+then pass
+then allow
+```
+
+`status` as a parameter of the disruptive action, not a separate data action.
+
+### Side-Effect Statements
+
+The block body contains zero or more side-effect statements:
+
+#### Variable Assignment
+
+```
+tx.anomaly_score += 5          # was: setvar:'tx.anomaly_score=+5'
+tx.sql_injection_score += 5    # was: setvar:'tx.sql_injection_score=+5'
+tx.blocking_early = 1          # was: setvar:'tx.blocking_early=1'
+ip.reput_block_flag = 1        # was: setvar:'ip.reput_block_flag=1'
+```
+
+Assignment operators:
+- `=`  — set (was: `setvar:'collection.var=value'`)
+- `+=` — increment (was: `setvar:'collection.var=+value'`)
+- `-=` — decrement (was: `setvar:'collection.var=-value'`)
+
+Variable expiry:
+
+```
+tx.block_duration = 3600 (expires: 3600)   # was: expirevar:'tx.block_duration=3600'
+```
+
+#### Logging
+
+```
+log()                    # was: action: log
+audit_log()              # was: action: auditlog
+log(data: "%{MATCHED_VAR}")  # was: logdata:'%{MATCHED_VAR}'
+```
+
+Or combined (since most rules use both):
+
+```
+log(audit: true)         # log + auditlog
+log(audit: true, data: matched.var)
+```
+
+#### Capture
+
+```
+capture()                # was: action: capture
+```
+
+#### Engine Configuration
+
+```
+configure {
+  force_request_body = true    # was: ctl:forceRequestBodyVariable=On
+  request_body_processor = XML # was: ctl:requestBodyProcessor=XML
+  rule_engine = detect_only    # was: ctl:ruleEngine=DetectOnly
+  audit_engine = off           # was: ctl:auditEngine=Off
+}
+```
+
+Or inline for single settings:
+
+```
+configure(request_body_processor: XML)
+```
+
+### Complete Examples
+
+**Simple block with scoring:**
+```
+rule 941100 (phase: request, severity: critical) {
+  when request.args |> js_decode() |> detect_xss()
+  then block {
+    tx.xss_score += 5
+    tx.anomaly_score += 5
+    capture()
+    log(audit: true, data: matched.var)
+  }
+}
+```
+
+**Pass with configuration:**
+```
+rule 900100 (phase: request) {
+  when true
+  then pass {
+    tx.paranoia_level = 1
+    tx.anomaly_score_threshold = 5
+  }
+}
+```
+
+**Deny with status:**
+```
+rule 901001 (phase: request, severity: critical) {
+  when count(tx.crs_setup_version) |> eq(0)
+  then deny(status: 500) {
+    log(audit: true)
+  }
+}
+```
+
+### IR Representation
+
+```go
+type ActionBlock struct {
+    Action     DisruptiveAction
+    Parameters map[string]Value    // status, url, etc.
+    Effects    []Effect
+}
+
+type Effect interface {
+    effectNode()
+}
+
+type VarAssignment struct {
+    Target   FieldRef       // tx.anomaly_score
+    Operator AssignOp       // Set, Add, Subtract
+    Value    Value
+    Expiry   *int           // optional TTL in seconds
+}
+
+type LogEffect struct {
+    Audit bool
+    Data  *FieldRef         // optional logdata field
+}
+
+type CaptureEffect struct{}
+
+type ConfigureEffect struct {
+    Settings map[string]Value
+}
+```
+
+### YAML v2 Representation
+
+```yaml
+then:
+  action: block
+  params:
+    status: 403
+  effects:
+    - assign:
+        target: tx.anomaly_score
+        op: "+="
+        value: 5
+    - log:
+        audit: true
+        data: matched.var
+    - capture: true
+```
+
+### Flow Actions
+
+- **`chain`** — eliminated entirely (ADR-0003)
+- **`skip`/`skipAfter`** — replaced by rule ordering and labels:
+
+  ```
+  # was: skipAfter:END_RULE_GROUP
+  goto END_RULE_GROUP     # or: skip to END_RULE_GROUP
+
+  label END_RULE_GROUP    # was: SecMarker:END_RULE_GROUP
+  ```
+
+  Note: `skip`/`skipAfter` are rare in CRS and primarily used for backwards
+  compatibility. Consider deprecating in favor of explicit rule grouping (Phase 6).
+
+## Alternatives Considered
+
+### A: Keep the four-category bag, just improve syntax
+
+```yaml
+actions:
+  disruptive: deny
+  status: 403
+  setvar:
+    - tx.anomaly_score += 5
+  logging: [log, auditlog]
+```
+
+**Rejected because:**
+- Still carries the category model that confuses authors
+- Does not solve the fundamental problem of actions being a grab-bag
+
+### B: All actions as function calls
+
+```
+then {
+  deny(status: 403)
+  set(tx.anomaly_score, "+", 5)
+  log(audit: true)
+}
+```
+
+**Rejected because:**
+- The disruptive action is not a side-effect; it is the *outcome* of the rule.
+  It deserves syntactic prominence, not burial in a block.
+- `deny()` as a function call implies it could appear conditionally inside the block,
+  which should not be possible.
+
+### C: Separate `action` and `effects` keywords
+
+```
+rule 920170 {
+  when ...
+  action block(status: 403)
+  effects {
+    tx.anomaly_score += 5
+    log()
+  }
+}
+```
+
+**Considered viable** but adds a keyword without clear benefit over `then action { effects }`.
+
+## Consequences
+
+### Positive
+
+- Clear separation: the disruptive action is the rule's outcome; effects are
+  side-effects that happen when it matches
+- `setvar` string parsing eliminated; assignments use native syntax
+- `ctl:` directives get their own `configure` block instead of being overloaded
+  actions
+- Status is a parameter, not a separate action type
+- Familiar imperative syntax for the effect block
+
+### Negative
+
+- Two syntactic constructs for effects: assignment syntax (`tx.score += 5`) and
+  function syntax (`log()`, `capture()`). This is intentional — assignments and
+  function calls are conceptually different.
+- `configure {}` may need engine-specific settings that vary across backends
+
+### Risks
+
+- **Engine mapping** — some effects may not have equivalents in all target engines.
+  Define a core set that all backends must support and an extension mechanism for
+  engine-specific effects.
+- **Ordering semantics** — do effects execute in order? In parallel? Define this
+  explicitly (recommendation: ordered, top-to-bottom, matching SecLang behavior).

--- a/docs/adr/0005-parser-strategy.md
+++ b/docs/adr/0005-parser-strategy.md
@@ -11,10 +11,9 @@ CRSLang currently has two parsers:
 1. **SecLang parser** — ANTLR4-based, external dependency
    (`github.com/coreruleset/seclang_parser`). Parses `.conf` files into a parse tree,
    which a listener converts to the Go AST.
-2. **YAML parser** — Go's standard `encoding/yaml` package. Loads YAML directly into
-   typed structs.
+2. **YAML parser** — `go.yaml.in/yaml/v4`. Loads YAML directly into typed structs.
 
-Phase 5 introduces a third format: the native CRSLang text syntax. This ADR decides
+Phase 4 introduces a third format: the native CRSLang text syntax. This ADR decides
 how to build its parser.
 
 ## Decision
@@ -39,7 +38,7 @@ A hand-written parser provides:
 
 ```ebnf
 (* Top-level *)
-file           = { rule | config | comment } ;
+file           = { rule | globals | defaults | comment } ;
 
 (* Rules *)
 rule           = "rule" INTEGER metadata? "{" when_clause then_clause "}" ;
@@ -55,10 +54,12 @@ unary_expr     = "not" unary_expr
                | pipeline ;
 
 (* Pipelines *)
-pipeline       = field_ref { "|>" func_call } ;
+pipeline       = pipeline_source { "|>" func_call } ;
+pipeline_source= field_ref | func_call | literal | "(" expr ")" ;
 field_ref      = IDENT { "." IDENT } [ "[" selector "]" ] ;
 selector       = STRING | "!" STRING ;
 func_call      = IDENT "(" [ arg { "," arg } ] ")" ;
+literal        = STRING | INTEGER | "true" | "false" ;
 
 (* Actions *)
 then_clause    = "then" disruptive [ "(" named_args ")" ] [ effect_block ] ;
@@ -69,8 +70,9 @@ assignment     = field_ref assign_op value ;
 assign_op      = "=" | "+=" | "-=" ;
 configure_block= "configure" "{" { IDENT "=" value } "}" ;
 
-(* Configuration directives *)
-config         = "configure" IDENT value ;
+(* Globals and defaults *)
+globals        = "globals" "{" { key_value } "}" ;
+defaults       = "defaults" "{" { key_value } "}" ;
 
 (* Rule management *)
 exclude_rule   = "exclude" "rule" INTEGER ;
@@ -109,7 +111,7 @@ Source Text
 **Components:**
 
 1. **Lexer** (`parser/lexer.go`) — hand-written scanner producing tokens:
-   - Keywords: `rule`, `when`, `then`, `and`, `or`, `not`, `configure`, etc.
+   - Keywords: `rule`, `when`, `then`, `and`, `or`, `not`, `globals`, `defaults`, etc.
    - Operators: `|>`, `=`, `+=`, `-=`
    - Delimiters: `(`, `)`, `{`, `}`, `[`, `]`, `,`, `.`
    - Literals: strings, integers, identifiers
@@ -140,7 +142,7 @@ parser/
 
 ### Three-Importer Architecture
 
-After Phase 5, the system has three importers and two exporters sharing a single IR:
+After Phase 4, the system has three importers and two exporters sharing a single IR:
 
 ```
 SecLang (.conf) ──► ANTLR parser ──► SecLang AST ──► Normalize ──┐

--- a/docs/adr/0005-parser-strategy.md
+++ b/docs/adr/0005-parser-strategy.md
@@ -42,8 +42,9 @@ file           = { rule | globals | defaults | comment } ;
 
 (* Rules *)
 rule           = "rule" INTEGER metadata? "{" when_clause then_clause "}" ;
-metadata       = "(" key_value { "," key_value } ")" ;
-key_value      = IDENT ":" value ;
+metadata       = "(" metadata_kv { "," metadata_kv } ")" ;
+metadata_kv    = IDENT ":" value ;
+block_assign   = IDENT "=" value ;
 
 (* Conditions *)
 when_clause    = "when" expr ;
@@ -71,8 +72,9 @@ assign_op      = "=" | "+=" | "-=" ;
 configure_block= "configure" "{" { IDENT "=" value } "}" ;
 
 (* Globals and defaults *)
-globals        = "globals" "{" { key_value } "}" ;
-defaults       = "defaults" "{" { key_value } "}" ;
+globals        = "globals" "{" { block_assign | nested_block } "}" ;
+defaults       = "defaults" metadata? "{" { block_assign | func_call } "}" ;
+nested_block   = IDENT "{" { block_assign } "}" ;   (* e.g., scoring { ... } *)
 
 (* Rule management *)
 exclude_rule   = "exclude" "rule" INTEGER ;

--- a/docs/adr/0005-parser-strategy.md
+++ b/docs/adr/0005-parser-strategy.md
@@ -1,0 +1,263 @@
+# ADR-0005: Parser Strategy
+
+- **Status:** Proposed (see also [ADR-0009](0009-language-base-evaluation.md) for broader evaluation including HCL, CEL, and Expr)
+- **Date:** 2026-04-13
+- **Phase:** 4 (implementation of ADR-0009 decision)
+
+## Context
+
+CRSLang currently has two parsers:
+
+1. **SecLang parser** — ANTLR4-based, external dependency
+   (`github.com/coreruleset/seclang_parser`). Parses `.conf` files into a parse tree,
+   which a listener converts to the Go AST.
+2. **YAML parser** — Go's standard `encoding/yaml` package. Loads YAML directly into
+   typed structs.
+
+Phase 5 introduces a third format: the native CRSLang text syntax. This ADR decides
+how to build its parser.
+
+## Decision
+
+Build a **hand-written recursive-descent parser** in Go with no external dependencies.
+
+### Rationale
+
+The CRSLang grammar (see below) is small and regular. It does not need:
+- Ambiguous grammar resolution (no ambiguity by design)
+- Left-recursive rules (the grammar is LL(1) with minor lookahead)
+- Grammar-driven code generation (the AST types already exist)
+
+A hand-written parser provides:
+- **Zero dependencies** — no ANTLR runtime, no build-time code generation
+- **Clear error messages** — custom error recovery with context-aware messages
+- **Full control** — easy to add syntax extensions without regenerating code
+- **Performance** — no generic parser overhead
+- **Debuggability** — step through parsing in a standard Go debugger
+
+### Grammar
+
+```ebnf
+(* Top-level *)
+file           = { rule | config | comment } ;
+
+(* Rules *)
+rule           = "rule" INTEGER metadata? "{" when_clause then_clause "}" ;
+metadata       = "(" key_value { "," key_value } ")" ;
+key_value      = IDENT ":" value ;
+
+(* Conditions *)
+when_clause    = "when" expr ;
+expr           = and_expr { "or" and_expr } ;
+and_expr       = unary_expr { "and" unary_expr } ;
+unary_expr     = "not" unary_expr
+               | "(" expr ")"
+               | pipeline ;
+
+(* Pipelines *)
+pipeline       = field_ref { "|>" func_call } ;
+field_ref      = IDENT { "." IDENT } [ "[" selector "]" ] ;
+selector       = STRING | "!" STRING ;
+func_call      = IDENT "(" [ arg { "," arg } ] ")" ;
+
+(* Actions *)
+then_clause    = "then" disruptive [ "(" named_args ")" ] [ effect_block ] ;
+disruptive     = "pass" | "block" | "deny" | "drop" | "allow" | "redirect" ;
+effect_block   = "{" { effect_stmt } "}" ;
+effect_stmt    = assignment | func_call | configure_block ;
+assignment     = field_ref assign_op value ;
+assign_op      = "=" | "+=" | "-=" ;
+configure_block= "configure" "{" { IDENT "=" value } "}" ;
+
+(* Configuration directives *)
+config         = "configure" IDENT value ;
+
+(* Rule management *)
+exclude_rule   = "exclude" "rule" INTEGER ;
+update_rule    = "update" "rule" INTEGER "{" update_body "}" ;
+
+(* Literals *)
+value          = STRING | INTEGER | FLOAT | BOOLEAN | list ;
+list           = "[" [ value { "," value } ] "]" ;
+
+(* Tokens *)
+STRING         = '"' { char } '"' ;
+INTEGER        = digit { digit } ;
+IDENT          = letter { letter | digit | "_" } ;
+comment        = "#" { any } newline ;
+```
+
+### Parser Architecture
+
+```
+Source Text
+    │
+    ▼
+┌──────────┐     ┌──────────┐     ┌──────────┐
+│  Lexer   │────▶│  Parser  │────▶│   AST    │
+│ (tokens) │     │ (recdes) │     │ (Go IR)  │
+└──────────┘     └──────────┘     └──────────┘
+                                       │
+                              ┌────────┴────────┐
+                              ▼                  ▼
+                         ┌─────────┐      ┌──────────┐
+                         │  YAML   │      │ SecLang  │
+                         │ export  │      │ export   │
+                         └─────────┘      └──────────┘
+```
+
+**Components:**
+
+1. **Lexer** (`parser/lexer.go`) — hand-written scanner producing tokens:
+   - Keywords: `rule`, `when`, `then`, `and`, `or`, `not`, `configure`, etc.
+   - Operators: `|>`, `=`, `+=`, `-=`
+   - Delimiters: `(`, `)`, `{`, `}`, `[`, `]`, `,`, `.`
+   - Literals: strings, integers, identifiers
+   - Comments: `#` to end of line
+
+2. **Parser** (`parser/parser.go`) — recursive-descent functions:
+   - One function per grammar production
+   - Returns typed AST nodes (shared with YAML and SecLang importers)
+   - Produces clear errors with line/column information
+
+3. **Error recovery** — on syntax error:
+   - Report the error with context (expected vs found, surrounding tokens)
+   - Attempt to synchronize at the next `rule` keyword or `}`
+   - Continue parsing to find multiple errors in one pass
+
+### Package Structure
+
+```
+parser/
+├── lexer.go          # Token scanner
+├── lexer_test.go
+├── token.go          # Token types
+├── parser.go         # Recursive-descent parser
+├── parser_test.go
+├── error.go          # Error types and formatting
+└── printer.go        # AST -> CRSLang text (formatter/pretty-printer)
+```
+
+### Three-Importer Architecture
+
+After Phase 5, the system has three importers and two exporters sharing a single IR:
+
+```
+SecLang (.conf) ──► ANTLR parser ──► SecLang AST ──► Normalize ──┐
+                                                                   │
+YAML (.yaml)   ──► yaml.Unmarshal ──► YAML structs ──► Normalize ─┤──► Unified IR
+                                                                   │
+CRSLang (.crs) ──► Hand-written ──► AST nodes ────────────────────┘
+                    parser                                │
+                                                          ├──► YAML exporter
+                                                          ├──► CRSLang text exporter
+                                                          └──► SecLang exporter (existing)
+```
+
+### WASM/Playground Integration
+
+The hand-written parser compiles to WASM without issues (no CGo, no external deps).
+The playground gains a third pane/mode for the native syntax:
+
+```javascript
+// Existing
+seclangToCRSLang(input)    // SecLang -> YAML
+crslangToSeclang(input)    // YAML -> SecLang
+
+// New
+parseCRSLang(input)        // CRSLang text -> IR (validates)
+formatCRSLang(ir)          // IR -> CRSLang text (pretty-print)
+crslangTextToYaml(input)   // CRSLang text -> YAML
+crslangTextToSeclang(input)// CRSLang text -> SecLang
+```
+
+### Formatting Conventions
+
+The pretty-printer enforces consistent style:
+
+```
+# One condition per line, aligned
+rule 920170 (phase: request, severity: warning) {
+  when request.method |> matches("^(?:GET|HEAD)$")
+   and request.headers["Content-Length"] |> not(matches("^0?$"))
+  then block {
+    tx.anomaly_score += 5
+    log(audit: true)
+  }
+}
+
+# Short rules on fewer lines
+rule 900100 (phase: request) {
+  when true
+  then pass { tx.paranoia_level = 1 }
+}
+```
+
+Indentation: 2 spaces. Line width guide: 100 characters. `and`/`or` align under `when`.
+
+## Alternatives Considered
+
+### A: ANTLR4 for the new syntax
+
+Use ANTLR4 (same as SecLang parser) with a new `.g4` grammar.
+
+**Rejected because:**
+- Adds build-time code generation step
+- ANTLR runtime is a heavy dependency for a small grammar
+- Generated code is hard to customize for error messages
+- The SecLang grammar is complex (legacy syntax); the CRSLang grammar is intentionally
+  simple and does not need ANTLR's power
+
+### B: PEG parser (pigeon, peg)
+
+Use a PEG parser generator for Go.
+
+**Considered viable but:**
+- Still requires code generation
+- PEG's ordered alternation can produce surprising behavior
+- Error messages from PEG parsers are typically poor
+- For this grammar size, hand-writing is faster than debugging a PEG grammar
+
+### C: Parser combinator library (participle)
+
+Use a Go parser combinator library that derives the parser from struct tags.
+
+**Considered viable but:**
+- Adds a runtime dependency
+- Grammar changes require changing struct definitions, coupling syntax to IR
+- Less control over error messages and recovery
+- The CRSLang IR already exists; forcing it to match a combinator library's
+  conventions would be counterproductive
+
+### D: Tree-sitter grammar
+
+Write a Tree-sitter grammar for editor integration, use it as the parser.
+
+**Rejected as primary parser** — Tree-sitter is designed for incremental editor parsing,
+not batch compilation. However, a Tree-sitter grammar **should be written alongside** the
+hand-written parser for editor support (syntax highlighting, code folding, etc.).
+
+## Consequences
+
+### Positive
+
+- Zero new dependencies
+- Compiles to WASM without issues
+- Full control over error messages and recovery
+- Easy to extend as the language grows
+- Debuggable with standard Go tools
+- Fast compilation (no code generation step)
+
+### Negative
+
+- More initial code to write than using a parser generator
+- No grammar file that doubles as documentation (mitigated by the EBNF in this ADR
+  and a separate grammar reference document)
+- Must be kept in sync with any Tree-sitter grammar manually
+
+### Risks
+
+- **Grammar evolution** — as the language grows, the hand-written parser must be updated
+  in lockstep. Mitigated by comprehensive parser tests and the small grammar size.
+- **Edge cases** — hand-written parsers can have subtle bugs in lookahead and error
+  recovery. Mitigated by fuzzing and property-based testing.

--- a/docs/adr/0006-rule-management.md
+++ b/docs/adr/0006-rule-management.md
@@ -1,0 +1,349 @@
+# ADR-0006: Rule Management Directives
+
+- **Status:** Proposed
+- **Date:** 2026-04-13
+- **Phase:** 5
+
+## Context
+
+SecLang provides several directives for modifying rules after they are defined. These are
+essential for CRS deployments where users need to customize rules without editing the
+core ruleset:
+
+- **`SecRuleRemoveById`** — disable a rule entirely by ID
+- **`SecRuleRemoveByTag`** — disable all rules matching a tag
+- **`SecRuleRemoveByMsg`** — disable all rules matching a message string
+- **`SecRuleUpdateTargetById`** — add or remove targets from a rule
+- **`SecRuleUpdateTargetByTag`** — add or remove targets from rules by tag
+- **`SecRuleUpdateTargetByMsg`** — add or remove targets from rules by message
+- **`SecRuleUpdateActionById`** — replace actions on a rule
+- **`SecMarker`** — named label for `skipAfter` control flow
+
+CRSLang v1 models these directly:
+
+```yaml
+- kind: remove
+  metadata:
+    comment: "Disable SQL injection check for admin API"
+  selector:
+    by_id: 942100
+
+- kind: update_target
+  selector:
+    by_id: 920170
+  collections:
+    - name: ARGS
+      arguments: [username]
+      excluded: true
+```
+
+### Problems
+
+1. **Selector inconsistency** — three selector types (by_id, by_tag, by_msg) with
+   identical behavior but different fields.
+2. **Target updates are complex** — adding and removing targets uses the same
+   `collections` structure with an `excluded` flag, mixing positive and negative
+   modifications.
+3. **Action updates are opaque** — `SecRuleUpdateActionById` replaces the entire action
+   list, which is error-prone and hard to review.
+4. **No composition** — you cannot say "for all rules in phase 1 with tag X, remove
+   target Y." Each operation is a standalone directive.
+5. **SecMarker** — a control-flow label that exists only because `skipAfter` needs a
+   target. If `skip`/`skipAfter` are deprecated (ADR-0004), markers may become
+   unnecessary.
+
+## Decision
+
+Introduce first-class **rule management directives** with a unified selector system and
+explicit modification operations.
+
+### Exclude (Remove) Rules
+
+```
+# By ID
+exclude rule 942100
+
+# By tag
+exclude rules where tag == "OWASP_CRS/SQL_INJECTION"
+
+# By tag pattern
+exclude rules where tag |> matches("^OWASP_CRS/SQL.*")
+
+# By severity
+exclude rules where severity == "CRITICAL"
+
+# Combined
+exclude rules where tag == "OWASP_CRS/SQL_INJECTION" and phase == request
+```
+
+### Update Targets
+
+```
+# Remove a specific target from a rule
+update rule 920170 {
+  remove target request.args["username"]
+}
+
+# Add a target
+update rule 920170 {
+  add target request.headers["X-Custom"]
+}
+
+# By tag — apply to all matching rules
+update rules where tag == "OWASP_CRS/SQL_INJECTION" {
+  remove target request.args["search_query"]
+}
+```
+
+### Update Actions
+
+Rather than replacing the entire action block, provide surgical modifications:
+
+```
+# Change disruptive action
+update rule 920170 {
+  set action pass
+}
+
+# Change severity
+update rule 920170 {
+  set severity WARNING
+}
+
+# Add an effect
+update rule 920170 {
+  add effect tx.custom_score += 10
+}
+
+# Remove an effect
+update rule 920170 {
+  remove effect capture()
+}
+```
+
+### Rule Groups
+
+Named groups replace `SecMarker` and provide a scope for batch operations:
+
+```
+group sql_injection_checks {
+  rule 942100 (...) { ... }
+  rule 942110 (...) { ... }
+  rule 942120 (...) { ... }
+}
+
+# Exclude the entire group
+exclude group sql_injection_checks
+
+# Update all rules in a group
+update group sql_injection_checks {
+  remove target request.args["allowed_field"]
+}
+```
+
+### Unified Selector System
+
+All management directives use the same selector grammar:
+
+```
+selector       = "rule" INTEGER                              # single rule by ID
+               | "rules" "where" selector_expr               # multiple rules by query
+               | "group" IDENT                               # named group
+
+selector_expr  = selector_expr "and" selector_expr
+               | selector_expr "or" selector_expr
+               | selector_field "==" value
+               | selector_field "|>" func_call
+               | "(" selector_expr ")"
+
+selector_field = "tag" | "phase" | "severity" | "id" | "message"
+```
+
+### Ordering and Scope
+
+Rule management directives are processed in file order, after all rules are loaded.
+This matches SecLang's behavior where removal/update directives in a later file affect
+rules from earlier files.
+
+For CRS deployments, the convention is:
+
+```
+# Core rules (provided by CRS)
+rules/
+  REQUEST-901-INITIALIZATION.crs
+  REQUEST-941-APPLICATION-ATTACK-XSS.crs
+  REQUEST-942-APPLICATION-ATTACK-SQLI.crs
+  ...
+
+# User customizations (site-specific)
+customizations/
+  exclude-false-positives.crs      # exclude/update directives
+  site-specific-rules.crs          # additional rules
+```
+
+### IR Representation
+
+```go
+type ExcludeDirective struct {
+    Selector RuleSelector
+    Comment  string
+}
+
+type UpdateDirective struct {
+    Selector     RuleSelector
+    Modifications []Modification
+    Comment      string
+}
+
+type RuleSelector interface {
+    selectorNode()
+}
+
+type ByIDSelector struct {
+    ID int
+}
+
+type WhereSelector struct {
+    Expr SelectorExpr  // boolean expression over rule metadata
+}
+
+type GroupSelector struct {
+    Name string
+}
+
+type Modification interface {
+    modNode()
+}
+
+type AddTarget struct {
+    Target FieldRef
+}
+
+type RemoveTarget struct {
+    Target FieldRef
+}
+
+type SetAction struct {
+    Action DisruptiveAction
+}
+
+type SetMetadata struct {
+    Field string
+    Value Value
+}
+
+type AddEffect struct {
+    Effect Effect
+}
+
+type RemoveEffect struct {
+    Effect Effect
+}
+```
+
+### YAML v2 Representation
+
+```yaml
+- kind: exclude
+  comment: "Disable SQL injection check for admin API"
+  selector:
+    rule: 942100
+
+- kind: exclude
+  selector:
+    where:
+      tag: "OWASP_CRS/SQL_INJECTION"
+      phase: request
+
+- kind: update
+  selector:
+    rule: 920170
+  modifications:
+    - remove_target: request.args["username"]
+    - add_target: request.headers["X-Custom"]
+
+- kind: update
+  selector:
+    where:
+      tag: "OWASP_CRS/SQL_INJECTION"
+  modifications:
+    - set_action: pass
+```
+
+### Migration from SecLang
+
+| SecLang | CRSLang |
+|---------|---------|
+| `SecRuleRemoveById 942100` | `exclude rule 942100` |
+| `SecRuleRemoveByTag "SQL_INJECTION"` | `exclude rules where tag == "SQL_INJECTION"` |
+| `SecRuleUpdateTargetById 920170 "!ARGS:username"` | `update rule 920170 { remove target request.args["username"] }` |
+| `SecRuleUpdateActionById 920170 "pass"` | `update rule 920170 { set action pass }` |
+| `SecMarker END_SQL_CHECKS` | `group sql_checks { ... }` (or label if skip is needed) |
+
+## Alternatives Considered
+
+### A: Inheritance / Override Model
+
+```
+rule 920170 extends base:920170 {
+  exclude target request.args["username"]
+  override action pass
+}
+```
+
+**Rejected because:**
+- Implies a class hierarchy that does not exist
+- Conflates "I want to modify this rule" with "I want to define a new rule based on it"
+- The `extends` keyword suggests the original rule still runs, which is confusing
+
+### B: Annotation-Based
+
+```
+@exclude(942100)
+@remove_target(920170, request.args["username"])
+```
+
+**Rejected because:**
+- Annotations are typically metadata, not imperative operations
+- Does not support the `where` selector pattern
+- Visually disconnected from the rules they affect
+
+### C: Separate Configuration File Format
+
+Use TOML, JSON, or a custom format for exclusions, keeping rule management separate
+from rule definitions.
+
+**Rejected because:**
+- Forces users to learn a second file format
+- The management directives are part of the rule language — they reference fields,
+  targets, and actions using the same syntax
+- Separate formats prevent tooling from validating references
+
+## Consequences
+
+### Positive
+
+- Unified selector system replaces three separate selector types
+- Surgical updates instead of full action replacement
+- Rule groups provide natural scoping for batch operations
+- Same expression syntax in selectors and conditions (reuse of `|>`, `matches()`, etc.)
+- Clear, readable exclusion files for CRS deployments
+
+### Negative
+
+- The `where` selector adds query-like complexity to what is currently a simple
+  ID/tag/msg lookup
+- Rule groups are a new organizational concept that must be adopted by CRS maintainers
+- Processing order must be well-defined to avoid surprises
+
+### Risks
+
+- **Selector performance** — `where` queries over large rulesets need efficient
+  evaluation. For CRS-sized rulesets (~300 rules) this is not a concern; for very
+  large custom rulesets, consider indexing by tag and phase.
+- **Circular modifications** — an update that changes a tag could affect which rules
+  another `where` selector matches. Define processing as single-pass: selectors
+  evaluate against the original rule state, not the modified state.
+- **Group adoption** — CRS rules are currently organized by file, not by explicit
+  groups. Groups are optional and additive — existing file-based organization continues
+  to work.

--- a/docs/adr/0006-rule-management.md
+++ b/docs/adr/0006-rule-management.md
@@ -70,7 +70,7 @@ exclude rules where tag == "OWASP_CRS/SQL_INJECTION"
 exclude rules where tag |> matches("^OWASP_CRS/SQL.*")
 
 # By severity
-exclude rules where severity == "CRITICAL"
+exclude rules where severity == critical
 
 # Combined
 exclude rules where tag == "OWASP_CRS/SQL_INJECTION" and phase == request
@@ -107,7 +107,7 @@ update rule 920170 {
 
 # Change severity
 update rule 920170 {
-  set severity WARNING
+  set severity warning
 }
 
 # Add an effect

--- a/docs/adr/0006-rule-management.md
+++ b/docs/adr/0006-rule-management.md
@@ -206,15 +206,20 @@ group "xss_pl2" (requires: paranoia >= 2) {
 
 # Compiled SecLang
 SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" \
-    "id:941012,phase:2,pass,nolog,skipAfter:END-xss-pl2"
+    "id:<generated>,phase:2,pass,nolog,skipAfter:END-xss-pl2"
 SecRule ... "id:941120,..."
 SecMarker "END-xss-pl2"
 ```
 
+**Compiler-generated rule IDs:** Guard rules need unique SecLang IDs. The compiler
+derives these deterministically from the group name and the lowest enclosed rule ID
+(e.g., `941120` → guard rule `941119` or a reserved offset range). The exact policy is
+an implementation concern; it must produce stable IDs across compilations so that CRS
+users can reference them in exclusions.
+
 This replaces `skip_to()`, `goto`, and `label` entirely. CRSLang expresses the intent
 (conditional activation), not the mechanism (skip/marker). See also ADR-0004 and
 ADR-0011 where paranoia levels as rule attributes enable automatic guard generation.
-```
 
 ### Unified Selector System
 
@@ -353,7 +358,7 @@ type RemoveEffect struct {
 | `SecRuleRemoveByTag "SQL_INJECTION"` | `exclude rules where tag == "SQL_INJECTION"` |
 | `SecRuleUpdateTargetById 920170 "!ARGS:username"` | `update rule 920170 { remove target request.args["username"] }` |
 | `SecRuleUpdateActionById 920170 "pass"` | `update rule 920170 { set action pass }` |
-| `SecMarker END_SQL_CHECKS` | `group sql_checks { ... }` (or label if skip is needed) |
+| `SecMarker END_SQL_CHECKS` + `skipAfter:END_SQL_CHECKS` | `group sql_checks (requires: ...) { ... }` |
 
 ## Alternatives Considered
 

--- a/docs/adr/0006-rule-management.md
+++ b/docs/adr/0006-rule-management.md
@@ -76,10 +76,39 @@ exclude rules where severity == critical
 exclude rules where tag == "OWASP_CRS/SQL_INJECTION" and phase == request
 ```
 
+### Target-Level Exclusions (Shorthand)
+
+The most common CRS user customization is "disable rule X for argument Y" — a
+target-level exclusion. This is the equivalent of SecLang's
+`ctl:ruleTargetRemoveById=942100;ARGS:passwd`. A shorthand syntax avoids the verbosity
+of a full `update` block for this common case:
+
+```
+# Shorthand: most common exclusion pattern
+exclude rule 942100 target request.args["passwd"]
+exclude rule 942100 target request.args["username"]
+
+# Multiple targets from one rule
+exclude rule 942100 target request.args["passwd"], request.args["token"]
+
+# By tag with target
+exclude rules where tag == "OWASP_CRS/SQL_INJECTION" target request.args["search_query"]
+```
+
+This compiles to SecLang as:
+```
+SecRule ... "ctl:ruleRemoveTargetById=942100;ARGS:passwd"
+# Or in a REQUEST-900 exclusion file:
+SecRuleUpdateTargetById 942100 "!ARGS:passwd"
+```
+
+The shorthand covers the vast majority of CRS user customization. For more complex
+modifications, the full `update` block syntax is available.
+
 ### Update Targets
 
 ```
-# Remove a specific target from a rule
+# Remove a specific target from a rule (full syntax)
 update rule 920170 {
   remove target request.args["username"]
 }
@@ -123,7 +152,10 @@ update rule 920170 {
 
 ### Rule Groups
 
-Named groups replace `SecMarker` and provide a scope for batch operations:
+Named groups replace `SecMarker` and provide both a scope for batch operations and
+**conditional activation** via guard clauses.
+
+**Basic groups** — organize rules and enable batch operations:
 
 ```
 group sql_injection_checks {
@@ -139,6 +171,49 @@ exclude group sql_injection_checks
 update group sql_injection_checks {
   remove target request.args["allowed_field"]
 }
+```
+
+**Guarded groups** — replace `skip`/`skipAfter`/`SecMarker` with conditional activation.
+The `requires` clause is a boolean expression over rule metadata or TX fields. Rules in
+the group only evaluate when the guard is true:
+
+```
+# Paranoia level gating (the primary use case for skip/marker in CRS)
+group "xss_pl1" (requires: paranoia >= 1) {
+  rule 941100 (severity: critical) { ... }
+  rule 941110 (severity: critical) { ... }
+}
+
+group "xss_pl2" (requires: paranoia >= 2) {
+  rule 941120 (severity: critical) { ... }
+  rule 941130 (severity: critical) { ... }
+}
+
+# Custom guard (rare, replaces ad-hoc skip patterns)
+group "custom_checks" (requires: tx.enable_custom_checks |> eq(1)) {
+  rule 100001 { ... }
+  rule 100002 { ... }
+}
+```
+
+Guarded groups compile to SecLang as `skipAfter`/`SecMarker` pairs:
+
+```
+# CRSLang
+group "xss_pl2" (requires: paranoia >= 2) {
+  rule 941120 ...
+}
+
+# Compiled SecLang
+SecRule TX:DETECTION_PARANOIA_LEVEL "@lt 2" \
+    "id:941012,phase:2,pass,nolog,skipAfter:END-xss-pl2"
+SecRule ... "id:941120,..."
+SecMarker "END-xss-pl2"
+```
+
+This replaces `skip_to()`, `goto`, and `label` entirely. CRSLang expresses the intent
+(conditional activation), not the mechanism (skip/marker). See also ADR-0004 and
+ADR-0011 where paranoia levels as rule attributes enable automatic guard generation.
 ```
 
 ### Unified Selector System

--- a/docs/adr/0007-phase-inference.md
+++ b/docs/adr/0007-phase-inference.md
@@ -1,0 +1,264 @@
+# ADR-0007: Phase Inference from Field Types
+
+- **Status:** Proposed
+- **Date:** 2026-04-13
+- **Phase:** 1 (builds on ADR-0001)
+
+## Context
+
+SecLang requires every rule to declare a numeric phase (1-5) that controls when the rule
+evaluates during request processing:
+
+| Phase | Name | Available data |
+|-------|------|----------------|
+| 1 | Request Headers | Method, URI, headers, cookies, query string args |
+| 2 | Request Body | POST body, file uploads, multipart data |
+| 3 | Response Headers | Response status, response headers |
+| 4 | Response Body | Response body content |
+| 5 | Logging | Post-processing (rarely used in rules) |
+
+In CRSLang v1 phase is a string in metadata:
+
+```yaml
+metadata:
+  phase: "1"
+```
+
+This is redundant information in the vast majority of rules. If a rule inspects
+`REQUEST_HEADERS:Content-Type`, it must be phase 1. If it inspects `RESPONSE_BODY`, it
+must be phase 4. The phase is already implied by the fields the rule references.
+
+### How Phase Maps to Fields
+
+With the typed field namespace from ADR-0001:
+
+| Field prefix | Implied phase | SecLang phase |
+|---|---|---|
+| `request.method`, `request.uri`, `request.protocol`, `request.line` | request_headers | 1 |
+| `request.headers[*]`, `request.cookies[*]` | request_headers | 1 |
+| `request.args.get[*]`, `request.args.get.names` | request_headers | 1 |
+| `request.body`, `request.args.post[*]`, `request.args[*]` | request_body | 2 |
+| `multipart.*`, `files.*` | request_body | 2 |
+| `response.status`, `response.protocol` | response_headers | 3 |
+| `response.headers[*]` | response_headers | 3 |
+| `response.body` | response_body | 4 |
+| `tx.*`, `ip.*`, `global.*`, `session.*` | any (cross-phase) | context-dependent |
+| `matched.*`, `rule.*` | any (cross-phase) | context-dependent |
+| `client.ip`, `server.*` | any (cross-phase) | context-dependent |
+| `time.*`, `env.*` | any (cross-phase) | context-dependent |
+
+### Phase-Ambiguous Fields
+
+Some fields are available in all phases. When a rule uses **only** cross-phase fields
+(e.g., only `tx.*` variables), the phase cannot be inferred and must be declared
+explicitly.
+
+In CRS, this pattern appears in:
+- Initialization rules (phase 1, TX-only) — e.g., rule 901001 checking
+  `count(tx.crs_setup_version)`
+- Paranoia level skip rules (phase 1-4, TX-only) — e.g., rules 911011/911012 checking
+  `tx.detection_paranoia_level`
+- Scoring evaluation rules (phase 5, TX-only) — evaluating accumulated anomaly scores
+
+## Decision
+
+**Phase is inferred from field references when unambiguous, and explicitly declared only
+when needed.**
+
+### Inference Rules
+
+1. If a rule references any **request-headers-phase** field → phase is `request_headers`
+2. If a rule references any **request-body-phase** field → phase is `request_body`
+3. If a rule references any **response-headers-phase** field → phase is `response_headers`
+4. If a rule references any **response-body-phase** field → phase is `response_body`
+5. If a rule references only **cross-phase** fields → phase must be declared explicitly
+
+### Conflict Detection
+
+If a rule references fields from multiple phases, that is a **compile-time error**:
+
+```
+# ERROR: request.method is phase 1, response.body is phase 4
+rule 999999 {
+  when request.method |> eq("GET")
+   and response.body |> contains("error")
+  then block
+}
+```
+
+This is also an error in SecLang (you cannot inspect response body in phase 1), but
+SecLang does not detect it — it silently produces wrong results. CRSLang catches it
+at compile time.
+
+### Mixed Phase-Specific and Cross-Phase Fields
+
+When a rule mixes phase-specific and cross-phase fields, the phase-specific field wins:
+
+```
+# Phase is inferred as request_headers (from request.method)
+# tx.anomaly_score is cross-phase, so it does not affect inference
+rule 920170 {
+  when request.method |> matches("^(?:GET|HEAD)$")
+   and tx.some_flag |> eq(1)
+  then block
+}
+```
+
+### Explicit Phase Declaration
+
+When inference is not possible (TX-only rules) or when the author wants to override for
+clarity, phase is declared in metadata:
+
+```
+# Must declare phase — only TX fields used
+rule 901001 (phase: request_headers) {
+  when count(tx.crs_setup_version) |> eq(0)
+  then deny(status: 500)
+}
+
+# Paranoia skip rules duplicate across phases
+rule 911011 (phase: request_headers) {
+  when tx.detection_paranoia_level |> lt(1)
+  then pass { skip_to(END_METHOD_ENFORCEMENT) }
+}
+
+rule 911012 (phase: request_body) {
+  when tx.detection_paranoia_level |> lt(1)
+  then pass { skip_to(END_METHOD_ENFORCEMENT) }
+}
+```
+
+### Phase Names
+
+CRSLang uses descriptive phase names instead of numbers:
+
+| CRSLang name | SecLang number |
+|---|---|
+| `request_headers` | 1 |
+| `request_body` | 2 |
+| `response_headers` | 3 |
+| `response_body` | 4 |
+| `logging` | 5 |
+
+The text syntax also accepts short forms for ergonomics:
+
+| Short form | Full name |
+|---|---|
+| `request` | `request_headers` (most common request phase) |
+| `response` | `response_headers` (most common response phase) |
+
+### Compilation to SecLang
+
+When exporting to SecLang, the compiler maps inferred or declared phases back to numeric
+values. This is lossless:
+
+```
+# CRSLang (phase inferred from request.headers)
+rule 920170 {
+  when request.headers["Content-Type"] |> matches("^application/json")
+  then block
+}
+
+# Compiled SecLang
+SecRule REQUEST_HEADERS:Content-Type "@rx ^application/json" \
+    "id:920170,phase:1,block"
+```
+
+For rules with explicit phase:
+
+```
+# CRSLang
+rule 901001 (phase: request_headers) {
+  when count(tx.crs_setup_version) |> eq(0)
+  then deny(status: 500)
+}
+
+# Compiled SecLang
+SecRule &TX:crs_setup_version "@eq 0" \
+    "id:901001,phase:1,deny,status:500"
+```
+
+### Sub-Phase Ambiguity: `request.args`
+
+One field requires special handling: `request.args` (all arguments, GET + POST combined).
+In SecLang, `ARGS` includes both query string and POST body parameters. It is technically
+available in phase 1, but POST parameters are only populated after phase 2 processes the
+body.
+
+CRSLang resolves this:
+- `request.args.get` → unambiguously phase 1 (query string only)
+- `request.args.post` → unambiguously phase 2 (POST body only)
+- `request.args` (combined) → inferred as phase 2 (the latest phase needed to have
+  complete data)
+
+This matches CRS best practice: rules that inspect `ARGS` should run in phase 2 to
+ensure POST parameters are available.
+
+## Alternatives Considered
+
+### A: Always require explicit phase
+
+Keep phase as a required metadata field, even when it can be inferred.
+
+**Rejected because:**
+- Redundant in 80%+ of rules
+- Creates a maintenance burden: if a rule's targets change, the author must remember
+  to update the phase
+- Mismatches between declared phase and actual field usage become possible (and are
+  silent bugs)
+
+### B: Infer phase, never allow explicit declaration
+
+Always infer, error on TX-only rules that cannot be inferred.
+
+**Rejected because:**
+- TX-only rules are common in CRS (initialization, scoring, paranoia skipping)
+- Some rules intentionally run in specific phases for ordering reasons
+- Removes author control where it is legitimately needed
+
+### C: Phase as a rule attribute, not metadata
+
+```
+@phase(request_headers)
+rule 901001 { ... }
+```
+
+**Rejected because:**
+- Adds syntax weight for something that is usually inferred
+- Attributes/annotations are better reserved for cross-cutting concerns that affect
+  many rules (e.g., `@deprecated`, `@disabled`)
+
+## Consequences
+
+### Positive
+
+- Eliminates redundant metadata in the majority of rules
+- **Catches phase/field mismatches at compile time** — a class of silent bugs in SecLang
+  becomes a compile error in CRSLang
+- Descriptive phase names (`request_headers`) are clearer than numeric phases (`1`)
+- Lossless round-trip to SecLang: the compiler maps inferred phases to numbers
+- Reduces cognitive load: authors think about *what* data to inspect, not *when* the
+  engine should inspect it
+
+### Negative
+
+- Authors must understand inference rules to predict which phase their rule lands in
+- TX-only rules require explicit phase, creating two code paths
+- The `request.args` sub-phase resolution (→ phase 2) is a convention that must be
+  documented and understood
+- Short forms (`request` → `request_headers`) could cause confusion if someone means
+  `request_body`
+
+### Risks
+
+- **Inference surprises** — an author adds a `tx.*` check to a rule that was previously
+  inferred as phase 1. The phase does not change (TX is cross-phase), but the author
+  might expect it to. Clear compiler output ("phase: request_headers (inferred from
+  request.method)") mitigates this.
+- **Future phases** — if a WAF engine adds new phases (e.g., a WebSocket phase),
+  the field-to-phase mapping must be extended. The registry design from ADR-0001
+  accommodates this.
+- **Paranoia skip pattern** — the CRS pattern of duplicating TX-only rules across
+  phases (911011 in phase 1, 911012 in phase 2) becomes explicit phase declaration
+  for each copy. This is arguably better — it makes the duplication visible rather
+  than hiding it in metadata.

--- a/docs/adr/0007-phase-inference.md
+++ b/docs/adr/0007-phase-inference.md
@@ -116,15 +116,11 @@ rule 901001 (phase: request_headers) {
   then deny(status: 500)
 }
 
-# Paranoia skip rules duplicate across phases
-rule 911011 (phase: request_headers) {
-  when tx.detection_paranoia_level |> lt(1)
-  then pass { skip_to(END_METHOD_ENFORCEMENT) }
-}
-
-rule 911012 (phase: request_body) {
-  when tx.detection_paranoia_level |> lt(1)
-  then pass { skip_to(END_METHOD_ENFORCEMENT) }
+# Paranoia gating — replaced by guarded groups (ADR-0006)
+# Instead of skip rules duplicated across phases:
+group "method_enforcement_pl1" (requires: paranoia >= 1) {
+  rule 911100 (phase: request_headers) { ... }
+  rule 911101 (phase: request_body) { ... }
 }
 ```
 
@@ -258,7 +254,7 @@ rule 901001 { ... }
 - **Future phases** — if a WAF engine adds new phases (e.g., a WebSocket phase),
   the field-to-phase mapping must be extended. The registry design from ADR-0001
   accommodates this.
-- **Paranoia skip pattern** — the CRS pattern of duplicating TX-only rules across
-  phases (911011 in phase 1, 911012 in phase 2) becomes explicit phase declaration
-  for each copy. This is arguably better — it makes the duplication visible rather
-  than hiding it in metadata.
+- **Paranoia skip pattern** — the CRS pattern of duplicating TX-only skip rules across
+  phases is eliminated entirely by guarded groups (ADR-0006). Instead of per-phase skip
+  rules, a guarded group with `requires: paranoia >= N` handles conditional activation.
+  The compiler generates the appropriate per-phase skip/marker pairs for SecLang output.

--- a/docs/adr/0007-phase-inference.md
+++ b/docs/adr/0007-phase-inference.md
@@ -190,6 +190,12 @@ CRSLang resolves this:
 This matches CRS best practice: rules that inspect `ARGS` should run in phase 2 to
 ensure POST parameters are available.
 
+**Trade-off:** This choice prevents inspecting `request.args` at phase 1 for GET-only
+requests (where no POST body exists). Authors who need phase-1 inspection of query
+string arguments should use `request.args.get` explicitly. The alternative — inferring
+phase 1 and silently missing POST parameters — is a worse failure mode because it
+would produce false negatives on POST-based attacks.
+
 ## Alternatives Considered
 
 ### A: Always require explicit phase

--- a/docs/adr/0008-configuration-directives.md
+++ b/docs/adr/0008-configuration-directives.md
@@ -156,14 +156,17 @@ defaults {
 
 Default actions apply to all subsequent rules in the file that do not override them.
 
-**3. Markers → labels or groups (ADR-0006)**
+**3. Markers → guarded groups (ADR-0006)**
 
 ```
-# SecLang: SecMarker END_SQL_CHECKS
-label END_SQL_CHECKS
+# SecLang: SecRule ... "skipAfter:END_SQL_CHECKS"
+#          ... rules ...
+#          SecMarker END_SQL_CHECKS
 
-# Or, preferably:
-group sql_checks { ... }
+# CRSLang: express the intent, not the mechanism
+group "sql_checks" (requires: paranoia >= 1) {
+  rule 942100 { ... }
+}
 ```
 
 **4. Web app ID → file-level metadata**

--- a/docs/adr/0008-configuration-directives.md
+++ b/docs/adr/0008-configuration-directives.md
@@ -1,0 +1,350 @@
+# ADR-0008: Separation of Configuration Directives from Rule Language
+
+- **Status:** Proposed
+- **Date:** 2026-04-13
+- **Phase:** 0 (foundational — scoping decision for the language)
+
+## Context
+
+SecLang mixes engine configuration and rule definitions in the same file format. A
+typical CRS deployment interleaves ~60 configuration directives with rules:
+
+```
+SecRuleEngine DetectionOnly
+SecRequestBodyAccess On
+SecRequestBodyLimit 13107200
+SecRequestBodyNoFilesLimit 131072
+SecRequestBodyJsonDepthLimit 512
+SecPcreMatchLimit 500000
+SecPcreMatchLimitRecursion 500000
+
+SecRule REQUEST_HEADERS:Content-Type "@rx ^application/json" \
+    "id:200001,phase:1,pass,t:none,ctl:requestBodyProcessor=JSON"
+
+SecAuditEngine RelevantOnly
+SecAuditLog /var/log/modsec_audit.log
+SecAuditLogParts ABCFHZ
+SecAuditLogType Serial
+```
+
+CRSLang v1 models these as `ConfigurationDirective` — a struct with a `Name` (string
+enum of ~60 types) and a `Parameter` (opaque string):
+
+```go
+type ConfigurationDirective struct {
+    Kind      Kind
+    Metadata  *CommentMetadata
+    Name      ConfigurationDirectiveType  // "SecRuleEngine", "SecRequestBodyLimit", etc.
+    Parameter string                      // "DetectionOnly", "13107200", etc.
+}
+```
+
+### Problems
+
+1. **Mixed concerns** — engine tuning (body size limits, PCRE limits, log paths) and
+   detection logic (rules) live in the same file and the same IR. A rule author should
+   not need to think about `SecPcreMatchLimitRecursion`.
+
+2. **Deployment-specific** — configuration values change between environments (dev vs
+   staging vs prod, nginx vs Apache vs Envoy). Rules do not. Mixing them means either
+   duplicating rules across environments or templating config values out of rule files.
+
+3. **Engine-specific** — many directives are ModSecurity-specific (`SecHashEngine`,
+   `SecGuardianLog`, `SecStreamInBodyInspection`) or even version-specific (ModSec v2 vs
+   v3). A language targeting multiple engines (Coraza, cloud WAFs) cannot standardize
+   these.
+
+4. **Opaque parameters** — the `Parameter` field is an untyped string. There is no
+   validation that `SecRequestBodyLimit` receives an integer or that `SecRuleEngine`
+   receives one of `On|Off|DetectionOnly`.
+
+5. **No composition** — configuration directives cannot reference each other or be
+   conditional. They are flat key-value pairs scattered across files.
+
+### Directive Inventory
+
+The ~60 configuration directives in CRSLang v1 break down as follows:
+
+**Engine behavior (32 directives)** — how the WAF processes requests:
+
+| Category | Directives |
+|----------|-----------|
+| Rule engine | `SecRuleEngine`, `SecConnEngine`, `SecStatusEngine` |
+| Request body | `SecRequestBodyAccess`, `SecRequestBodyLimit`, `SecRequestBodyNoFilesLimit`, `SecRequestBodyInMemoryLimit`, `SecRequestBodyLimitAction`, `SecRequestBodyJsonDepthLimit` |
+| Response body | `SecResponseBodyAccess`, `SecResponseBodyLimit`, `SecResponseBodyLimitAction`, `SecResponseBodyMimeType`, `SecResponseBodyMimeTypesClear` |
+| PCRE tuning | `SecPcreMatchLimit`, `SecPcreMatchLimitRecursion` |
+| Paths | `SecDataDir`, `SecTmpDir`, `SecChrootDir` |
+| Connections | `SecConnReadStateLimit`, `SecConnWriteStateLimit`, `SecCollectionTimeout` |
+| Hashing | `SecHashEngine`, `SecHashKey`, `SecHashParam`, `SecHashMethodRx`, `SecHashMethodPm` |
+| Streaming | `SecStreamInBodyInspection`, `SecStreamOutBodyInspection` |
+| Misc engine | `SecContentInjection`, `SecDisableBackendCompression`, `SecInterceptOnError`, `SecXmlExternalEntity`, `SecCacheTransformations`, `SecArgumentSeparator`, `SecArgumentsLimit`, `SecCookieFormat`, `SecCookieV0Separator` |
+
+**Logging (12 directives)** — how and where to log:
+
+| Directives |
+|-----------|
+| `SecAuditEngine`, `SecAuditLog`, `SecAuditLog2`, `SecAuditLogFormat`, `SecAuditLogParts`, `SecAuditLogRelevantStatus`, `SecAuditLogType`, `SecAuditLogStorageDir`, `SecAuditLogDirMode`, `SecAuditLogFileMode` |
+| `SecDebugLog`, `SecDebugLogLevel` |
+| `SecGuardianLog` |
+
+**Uploads (4 directives):**
+
+| Directives |
+|-----------|
+| `SecUploadDir`, `SecUploadFileLimit`, `SecUploadFileMode`, `SecUploadKeepFiles`, `SecTmpSaveUploadedFiles` |
+
+**External data (3 directives):**
+
+| Directives |
+|-----------|
+| `SecGeoLookupDb`, `SecGsbLookupDb`, `SecUnicodeMapFile` |
+
+**Rule-adjacent metadata (5 directives)** — related to rules but not rules themselves:
+
+| Directive | Purpose |
+|-----------|---------|
+| `SecComponentSignature` | Declares the application/version protected |
+| `SecWebAppId` | Names the application context |
+| `SecDefaultAction` | Sets default phase/action for subsequent rules |
+| `SecMarker` | Label for `skipAfter` control flow |
+| `SecServerSignature` | Overrides the server header |
+
+**Operational (3 directives):**
+
+| Directives |
+|-----------|
+| `SecRemoteRulesFailAction`, `SecRuleInheritance`, `SecRulePerfTime`, `SecSensorId`, `SecHttpBlKey` |
+
+## Decision
+
+**CRSLang does not model engine configuration directives.** The rule language describes
+*what to detect*, not *how to run the engine*. Configuration belongs in a separate,
+engine-specific configuration layer.
+
+### What Stays in CRSLang
+
+Only **rule-adjacent metadata** that is part of the rule semantics:
+
+**1. Component signature → `component` declaration**
+
+```
+# SecLang: SecComponentSignature "OWASP_CRS/4.18.0-dev"
+component "OWASP_CRS" version "4.18.0-dev"
+```
+
+This identifies the ruleset, not the engine. It belongs in the rule file as a header.
+
+**2. Default actions → rule-level defaults block**
+
+```
+# SecLang: SecDefaultAction "phase:1,log,auditlog,pass"
+defaults (phase: request_headers) {
+  action: pass
+  log(audit: true)
+}
+```
+
+Or, if phase inference (ADR-0007) eliminates most explicit phase declarations, defaults
+may simplify to just the action and effects:
+
+```
+defaults {
+  action: pass
+  log(audit: true)
+}
+```
+
+Default actions apply to all subsequent rules in the file that do not override them.
+
+**3. Markers → labels or groups (ADR-0006)**
+
+```
+# SecLang: SecMarker END_SQL_CHECKS
+label END_SQL_CHECKS
+
+# Or, preferably:
+group sql_checks { ... }
+```
+
+**4. Web app ID → file-level metadata**
+
+```
+# SecLang: SecWebAppId "myapp"
+app "myapp"
+```
+
+### What Leaves CRSLang
+
+All engine behavior, logging, upload, path, PCRE, connection, hashing, and streaming
+directives. These are **not part of the rule language**.
+
+For CRS deployments, these settings move to an engine-specific configuration file:
+
+```yaml
+# engine.yaml (example — format is engine-specific, not standardized by CRSLang)
+engine:
+  mode: detection_only   # SecRuleEngine DetectionOnly
+
+request_body:
+  access: true           # SecRequestBodyAccess On
+  limit: 13107200        # SecRequestBodyLimit
+  no_files_limit: 131072 # SecRequestBodyNoFilesLimit
+  json_depth_limit: 512  # SecRequestBodyJsonDepthLimit
+
+response_body:
+  access: true           # SecResponseBodyAccess On
+  limit: 524288          # SecResponseBodyLimit
+  mime_types:            # SecResponseBodyMimeType
+    - text/html
+    - application/json
+
+pcre:
+  match_limit: 500000          # SecPcreMatchLimit
+  match_limit_recursion: 500000 # SecPcreMatchLimitRecursion
+
+audit:
+  engine: relevant_only  # SecAuditEngine RelevantOnly
+  log: /var/log/modsec_audit.log
+  format: JSON           # SecAuditLogFormat
+  parts: ABCFHZ          # SecAuditLogParts
+
+data:
+  geo_db: /usr/share/GeoIP/GeoLite2-Country.mmdb  # SecGeoLookupDb
+  unicode_map: /etc/modsec/unicode.mapping          # SecUnicodeMapFile
+```
+
+CRSLang does **not** standardize this format. Each engine (Coraza, ModSecurity, cloud
+WAFs) defines its own configuration schema. CRSLang only defines the rule language.
+
+### Runtime Overrides via `ctl:` Actions
+
+Some configuration can be changed per-rule via `ctl:` actions in SecLang. These are
+already handled by ADR-0004 as `configure {}` blocks inside rules:
+
+```
+rule 200001 {
+  when request.headers["Content-Type"] |> matches("^application/json")
+  then pass {
+    configure(request_body_processor: json)
+  }
+}
+```
+
+These are **rule-scoped overrides**, not global configuration. They remain in the rule
+language because they are conditional on the rule matching.
+
+The set of `ctl:` settings that CRSLang supports in `configure {}` blocks is a small,
+standardized subset that is expected to be portable across engines:
+
+| CRSLang | SecLang `ctl:` |
+|---------|---------------|
+| `request_body_processor` | `ctl:requestBodyProcessor` |
+| `request_body_access` | `ctl:requestBodyAccess` |
+| `response_body_access` | `ctl:responseBodyAccess` |
+| `rule_engine` | `ctl:ruleEngine` |
+| `force_request_body` | `ctl:forceRequestBodyVariable` |
+| `audit_engine` | `ctl:auditEngine` |
+| `audit_log_parts` | `ctl:auditLogParts` |
+| `rule_remove_by_id` | `ctl:ruleRemoveById` |
+| `rule_remove_by_tag` | `ctl:ruleRemoveByTag` |
+
+Engine-specific `ctl:` actions that are not portable go into an `engine_configure {}`
+escape hatch or are dropped on export to non-supporting engines.
+
+### SecLang Import/Export
+
+**Import:** When importing SecLang `.conf` files, configuration directives are:
+1. Recognized and parsed (for validation and reporting)
+2. Emitted as comments or a separate config section — **not** mixed into the rule IR
+3. A migration report lists extracted configuration with suggested engine-config
+   equivalents
+
+**Export:** When compiling CRSLang to SecLang:
+1. Rule-adjacent metadata (`component`, `defaults`, `app`) is emitted as the
+   corresponding SecLang directives
+2. Engine configuration is **not** emitted — the user provides it separately in their
+   engine config
+3. `configure {}` blocks compile to `ctl:` actions
+
+## Alternatives Considered
+
+### A: Model all configuration directives with typed fields
+
+Define a typed configuration schema in CRSLang covering all ~60 directives:
+
+```
+configure {
+  rule_engine = detection_only
+  request_body.limit = 13107200
+  pcre.match_limit = 500000
+  audit.log = "/var/log/modsec_audit.log"
+}
+```
+
+**Rejected because:**
+- Most directives are engine-specific and would not apply to all backends
+- CRSLang would need to track and update configuration options for every engine version
+- Conflates the rule language with engine deployment, the exact problem we are solving
+- Configuration drift: CRSLang's config schema would perpetually lag behind engine
+  releases
+
+### B: Configuration as a separate CRSLang file type
+
+Define a `.crsconfig` format alongside `.crs` rule files:
+
+```
+# engine.crsconfig
+rule_engine: detection_only
+request_body_limit: 13107200
+```
+
+**Rejected because:**
+- Still requires CRSLang to define and maintain a configuration schema
+- Adds a second file format to the CRSLang specification
+- Each engine already has its own config format; adding another creates more work
+  without clear benefit
+
+### C: Keep configuration directives as-is (passthrough)
+
+Import them, store them in the IR, export them unchanged.
+
+**Rejected because:**
+- Perpetuates the mixed-concerns problem
+- The IR carries engine-specific data that has no meaning in a multi-engine world
+- Prevents CRSLang from being engine-independent
+
+## Consequences
+
+### Positive
+
+- CRSLang becomes purely about detection logic — cleaner language, smaller spec
+- Engine independence: rules work across Coraza, ModSecurity, cloud WAFs without
+  carrying engine-specific config
+- Deployment configuration is managed with deployment tools (Ansible, Terraform, Helm)
+  rather than embedded in rule files
+- Smaller IR: ~60 directive types removed from the type system
+- The `ConfigurationDirective` struct and its ~60-entry enum can be removed from the
+  Go types (or relegated to the SecLang importer only)
+
+### Negative
+
+- CRS users accustomed to `SecRuleEngine On` at the top of their rule files must learn
+  to put it elsewhere
+- The SecLang importer must handle configuration directives gracefully (extract, report,
+  not error)
+- CRS documentation must clearly explain where configuration goes in a CRSLang-based
+  deployment
+- `SecDefaultAction` semantics (applying defaults to subsequent rules) must be carefully
+  preserved in the `defaults {}` block
+
+### Risks
+
+- **CRS setup file** — `crs-setup.conf` is a mix of configuration directives and
+  `SecAction` rules that initialize TX variables. The TX-initializing rules stay in
+  CRSLang; the engine config lines are extracted. The migration tooling must handle
+  this file specially.
+- **`ctl:` completeness** — if an engine adds new `ctl:` actions, the CRSLang
+  `configure {}` standardized set may lag behind. The `engine_configure {}` escape
+  hatch handles this, but rules using it are not portable.
+- **Documentation gap** — users need clear guidance on "I used to have one `.conf` file,
+  now I have CRSLang rules + engine config." Provide migration guides per engine.

--- a/docs/adr/0008-configuration-directives.md
+++ b/docs/adr/0008-configuration-directives.md
@@ -351,9 +351,10 @@ Import them, store them in the IR, export them unchanged.
 ### Risks
 
 - **CRS setup file** — `crs-setup.conf` is a mix of configuration directives and
-  `SecAction` rules that initialize TX variables. The TX-initializing rules stay in
-  CRSLang; the engine config lines are extracted. The migration tooling must handle
-  this file specially.
+  `SecAction` rules that initialize TX variables. The engine config lines are extracted
+  and moved to the engine-specific config file. The TX-initializing rules are replaced by
+  the `config {}` block defined in [ADR-0012](0012-ruleset-initialization.md), which the
+  compiler uses to generate initialization output. Migration tooling handles the split.
 - **`ctl:` completeness** — if an engine adds new `ctl:` actions, the CRSLang
   `configure {}` standardized set may lag behind. The `engine_configure {}` escape
   hatch handles this, but rules using it are not portable.

--- a/docs/adr/0008-configuration-directives.md
+++ b/docs/adr/0008-configuration-directives.md
@@ -87,7 +87,7 @@ The ~60 configuration directives in CRSLang v1 break down as follows:
 | `SecDebugLog`, `SecDebugLogLevel` |
 | `SecGuardianLog` |
 
-**Uploads (4 directives):**
+**Uploads (5 directives):**
 
 | Directives |
 |-----------|
@@ -109,7 +109,7 @@ The ~60 configuration directives in CRSLang v1 break down as follows:
 | `SecMarker` | Label for `skipAfter` control flow |
 | `SecServerSignature` | Overrides the server header |
 
-**Operational (3 directives):**
+**Operational (5 directives):**
 
 | Directives |
 |-----------|

--- a/docs/adr/0008-configuration-directives.md
+++ b/docs/adr/0008-configuration-directives.md
@@ -139,7 +139,7 @@ This identifies the ruleset, not the engine. It belongs in the rule file as a he
 ```
 # SecLang: SecDefaultAction "phase:1,log,auditlog,pass"
 defaults (phase: request_headers) {
-  action: pass
+  action = pass
   log(audit: true)
 }
 ```
@@ -149,12 +149,20 @@ may simplify to just the action and effects:
 
 ```
 defaults {
-  action: pass
+  action = pass
   log(audit: true)
 }
 ```
 
 Default actions apply to all subsequent rules in the file that do not override them.
+
+**Unlike SecLang's `SecDefaultAction`, CRSLang's `defaults {}` does not inject default
+transformations.** Each rule explicitly states its own transforms via pipelines or named
+macros. This eliminates the need for SecLang's `t:none` workaround (see ADR-0002).
+
+**Syntax convention** — `=` is used for assignments inside block bodies (`action =
+pass`, `version = "..."`) and `:` is used for metadata arguments in parentheses (`(phase:
+request_headers, severity: critical)`).
 
 **3. Markers → guarded groups (ADR-0006)**
 

--- a/docs/adr/0009-language-base-evaluation.md
+++ b/docs/adr/0009-language-base-evaluation.md
@@ -1,0 +1,552 @@
+# ADR-0009: Language Base Evaluation — HCL, CEL, Expr, or Custom Parser
+
+- **Status:** Proposed
+- **Date:** 2026-04-13
+- **Phase:** 0 (foundational — must decide before IR design in Phases 1-3)
+
+## Context
+
+ADR-0005 proposed a hand-written recursive-descent parser for CRSLang's text syntax.
+Before committing to building a parser from scratch, we should evaluate whether an
+existing language can serve as CRSLang's foundation — particularly given new requirements
+that emerged from design discussions:
+
+### New Requirements
+
+**1. Reusable transform composition (macros/functions)**
+
+CRS rules repeat the same transformation chains across many rules. Instead of spelling
+out 4-5 transforms per rule, authors should define named compositions:
+
+```
+# Instead of repeating this in every SQL injection rule:
+request.args |> url_decode() |> lowercase() |> remove_whitespace() |> detect_sqli()
+
+# Define once, use everywhere:
+detect_sqli(normalize(request.args))
+# Or with pipeline:
+request.args |> normalize() |> detect_sqli()
+```
+
+This means the pipeline operator (`|>`) is a per-rule convenience, not a language-level
+necessity. If transforms are encapsulated in named functions, nesting depth stays at 1-2
+levels, and nested function call syntax (`detect_sqli(normalize(field))`) is readable.
+
+**2. Global defaults (version, common tags)**
+
+CRS rules repeat `version: OWASP_CRS/4.18.0-dev` and `tag: OWASP_CRS` on every rule.
+CRSLang v1 already extracts these (`ExtractDefaultValues` in `configuration.go`). The
+new syntax should make this a first-class concept:
+
+```
+# Applied to all rules in all files
+globals {
+  version = "OWASP_CRS/4.18.0-dev"
+  tags    = ["OWASP_CRS"]
+}
+```
+
+**3. File-level / group-level defaults**
+
+Some tags and metadata repeat within a file or logical group but not globally:
+
+```
+# Applied to all rules in this file/group
+group "sql_injection" {
+  tags = ["OWASP_CRS/SQL_INJECTION", "attack-sqli"]
+
+  rule 942100 { ... }
+  rule 942110 { ... }
+}
+```
+
+**4. Condition expression is the key design question**
+
+The structural parts (rule blocks, metadata, groups, globals) are straightforward in
+any block-based language. The critical differentiator is how conditions are expressed —
+the boolean expressions with function calls that form the matching logic.
+
+## Evaluation Criteria
+
+| Criterion | Weight | Description |
+|-----------|--------|-------------|
+| Condition expressiveness | High | Can it express boolean combinations of field tests with transforms? |
+| Function composition | High | Can users define reusable transform chains? |
+| Block structure | Medium | Does it naturally support rules, groups, globals? |
+| Go ecosystem | Medium | Library quality, license, WASM support, maintenance |
+| Extensibility | Medium | Can we add CRSLang-specific constructs without forking? |
+| Learning curve | Medium | Familiarity for security engineers and DevOps |
+| Pipeline support | Low | Nice-to-have if macro functions reduce nesting (see above) |
+
+## Candidates
+
+### Option A: HCL2
+
+**Library:** `github.com/hashicorp/hcl/v2` (MPL-2.0)
+
+**Structure:**
+
+```hcl
+globals {
+  version = "OWASP_CRS/4.18.0-dev"
+  tags    = ["OWASP_CRS"]
+}
+
+group "sql_injection" {
+  tags = ["OWASP_CRS/SQL_INJECTION", "attack-sqli"]
+
+  rule "942100" {
+    severity = "critical"
+    message  = "SQL Injection Attack Detected"
+
+    condition = detect_sqli(normalize(request.args))
+    action    = "block"
+
+    effects {
+      tx_sqli_score    = "+=5"
+      tx_anomaly_score = "+=5"
+      capture          = true
+      log_audit        = true
+    }
+  }
+}
+
+exclude "rule" {
+  id = 942100
+}
+
+update "rule" {
+  id = 920170
+  remove_target = "request.args[\"username\"]"
+}
+```
+
+**Conditions:**
+
+```hcl
+# Simple match
+condition = matches(request.method, "^(?:GET|HEAD)$")
+
+# Boolean composition
+condition = (
+  matches(request.method, "^(?:GET|HEAD)$")
+  && !matches(request.headers["Content-Length"], "^0?$")
+)
+
+# With named transforms (custom functions registered in Go)
+condition = detect_xss(normalize_input(request.args))
+
+# Complex boolean
+condition = (
+  (eq(request.method, "POST") || eq(request.method, "PUT"))
+  && !contains(request.headers["Content-Type"], "application/json")
+  && gt(length(request.body), 0)
+)
+```
+
+**Custom functions:** Registered in Go via `function.New()`. CRSLang defines a function
+registry that includes both primitive transforms (`lowercase`, `url_decode`) and
+composite macros (`normalize_input` = url_decode + lowercase + remove_whitespace).
+Users can extend the registry with their own macros.
+
+Functions like Sprig (`github.com/Masterminds/sprig`) can be registered directly,
+giving access to 100+ utility functions (string manipulation, date formatting, crypto,
+etc.) for free.
+
+**Strengths:**
+- Block syntax is an excellent fit for rules, groups, globals
+- Widely known in DevOps/infrastructure community (Terraform)
+- Custom functions are trivial to add from Go
+- `&&`, `||`, `!` for boolean expressions work naturally
+- Sprig integration gives a rich function library for free
+- HCL's `for` expressions could enable iteration over collections
+- Mature parser with good error messages and recovery
+- Compiles to WASM (pure Go, no CGo)
+
+**Weaknesses:**
+- No pipeline operator (`|>`) — grammar is fixed, cannot be extended
+- Conditions are attribute values, not first-class syntax — they lack visual prominence
+- Function nesting reads inside-out (mitigated by named compositions)
+- `effects` block uses string values for operations (`"+=5"`) because HCL attributes
+  are assignments, not arbitrary statements
+- No `let` bindings in expressions for data-flow dependencies (ADR-0003 Category 3)
+- HCL variable references use `var.name` prefix which would need custom handling
+
+**Pipeline workaround with Go templates:**
+
+HCL2 supports Go template syntax in string interpolation, and Go templates have `|`
+(pipe) as a first-class operator. However, this only works inside strings:
+
+```hcl
+# This is string interpolation, not expression evaluation
+condition = "${request.args | normalize | detect_sqli}"
+```
+
+This is not viable — it would mean conditions are opaque strings, losing type checking
+and IDE support. The pipe in Go templates is for text rendering, not AST construction.
+
+### Option B: CEL (Common Expression Language)
+
+**Library:** `github.com/google/cel-go` (Apache-2.0)
+
+**Structure:** CEL is an expression-only language — it has no block syntax. It would need
+to be embedded inside another structural format (HCL, YAML, or custom blocks).
+
+**Hybrid approach — HCL for structure, CEL for conditions:**
+
+```hcl
+globals {
+  version = "OWASP_CRS/4.18.0-dev"
+  tags    = ["OWASP_CRS"]
+}
+
+rule "920170" {
+  severity = "warning"
+
+  # CEL expression as a string attribute, parsed by cel-go
+  condition = "request.method.matches('^(?:GET|HEAD)$') && !request.headers['Content-Length'].matches('^0?$')"
+
+  action = "block"
+  effects {
+    tx_anomaly_score = "+=5"
+  }
+}
+```
+
+**CEL expression examples:**
+
+```cel
+// Method chaining (CEL's strength)
+request.method.matches("^(?:GET|HEAD)$")
+
+// Boolean composition
+request.method.matches("^POST$") && request.body.size() > 0
+
+// With custom functions
+normalize(request.args).detect_sqli()
+
+// With macros (CEL supports parse-level macros)
+request.args.all(arg, !arg.detect_sqli())
+
+// Exists macro
+request.headers.exists(h, h.key == "X-Forwarded-For")
+```
+
+**Custom functions:** Defined in Go via `cel.Function()`. CEL also supports **custom
+macros** that rewrite the AST at parse time — more powerful than runtime functions.
+
+**Strengths:**
+- Purpose-built for policy and rule evaluation (Google IAM, Kubernetes, Envoy)
+- Method-style chaining: `field.transform().predicate()` — not a pipeline but close
+- CEL macros enable reusable compositions at the AST level
+- Strong type system with protocol buffer integration
+- Partial evaluation support (useful for optimization)
+- `has()` macro for optional field checks
+- Battle-tested in production at scale
+
+**Weaknesses:**
+- Expression-only — needs a structural wrapper (HCL, YAML, or custom)
+- Two parsers: one for structure, one for conditions
+- CEL expressions as strings inside HCL lose syntax highlighting and editor support
+- Method-style `field.transform()` creates ambiguity with field access (`request.headers`
+  vs `request.method.matches()` — is `.matches` a field or a method?)
+- Heavier dependency than HCL alone
+- WASM support: `cel-go` is pure Go and compiles to WASM, but the binary size is
+  significant
+
+### Option C: Expr
+
+**Library:** `github.com/expr-lang/expr` (MIT)
+
+**Structure:** Like CEL, Expr is expression-only and needs a structural wrapper.
+
+**Hybrid approach — HCL for structure, Expr for conditions:**
+
+```hcl
+rule "920170" {
+  condition = "matches(request.method, '^(?:GET|HEAD)$') && !matches(request.headers['Content-Length'], '^0?$')"
+  action    = "block"
+}
+```
+
+**Expr expression examples:**
+
+```
+// Function calls
+matches(request.method, "^(?:GET|HEAD)$")
+
+// Boolean
+matches(request.method, "POST") && length(request.body) > 0
+
+// Member access
+request.headers["Content-Type"] contains "json"
+
+// Built-in operators
+request.method in ["GET", "HEAD", "OPTIONS"]
+
+// With custom functions
+detect_sqli(normalize(request.args))
+```
+
+**Custom functions:** Defined in Go via `expr.Function()`. Expr also supports operator
+overloading.
+
+**Strengths:**
+- Very lightweight (MIT license, small dependency)
+- Fast evaluation (compiles to bytecode)
+- Simple API: `expr.Compile()` + `expr.Run()`
+- Built-in operators: `in`, `contains`, `matches`, `startsWith`, `endsWith`
+- Familiar syntax (similar to JavaScript/Python expressions)
+- Compiles to WASM easily
+
+**Weaknesses:**
+- No method chaining or pipeline
+- Less mature than CEL for policy use cases
+- No macro system — compositions must be runtime functions
+- Same two-parser problem as CEL
+- Expressions as strings lose editor support
+
+### Option D: Custom Parser (ADR-0005)
+
+**Library:** None — hand-written lexer + recursive-descent parser in Go.
+
+**Structure and conditions unified:**
+
+```
+globals {
+  version = "OWASP_CRS/4.18.0-dev"
+  tags    = ["OWASP_CRS"]
+}
+
+macro normalize(field) {
+  field |> url_decode() |> lowercase() |> compress_whitespace()
+}
+
+group "sql_injection" {
+  tags = ["OWASP_CRS/SQL_INJECTION", "attack-sqli"]
+
+  rule 942100 (severity: critical) {
+    when detect_sqli(normalize(request.args))
+      or detect_sqli(normalize(request.body))
+    then block {
+      tx.sqli_score += 5
+      tx.anomaly_score += 5
+      capture()
+      log(audit: true)
+    }
+  }
+}
+```
+
+**Strengths:**
+- Pipeline operator (`|>`) — native, first-class
+- `macro` / user-defined functions — in the language, not just in Go
+- Unified parser: structure and conditions in one grammar
+- Full control over syntax, error messages, and evolution
+- `let` bindings (ADR-0003) trivially addable
+- `when`/`then` keywords give conditions visual prominence
+- Assignment operators (`+=`, `-=`) native in effect blocks
+- Zero dependencies
+- WASM: trivial
+
+**Weaknesses:**
+- Must write and maintain the parser (~1500-2500 lines of Go)
+- No pre-existing editor support (must write Tree-sitter grammar, LSP, etc.)
+- No ecosystem of existing functions (Sprig, etc.) — must build the function library
+- Novel syntax — no existing community familiarity
+- Risk of language design mistakes without real-world iteration
+
+### Option E: HCL for Structure + Custom Expression Micro-Language for Conditions
+
+A hybrid that uses HCL for the block structure but replaces HCL's expression language
+with a custom parser for conditions only.
+
+```hcl
+globals {
+  version = "OWASP_CRS/4.18.0-dev"
+  tags    = ["OWASP_CRS"]
+}
+
+macro "normalize" {
+  steps = ["url_decode", "lowercase", "compress_whitespace"]
+}
+
+group "sql_injection" {
+  tags = ["OWASP_CRS/SQL_INJECTION", "attack-sqli"]
+
+  rule "942100" {
+    severity = "critical"
+
+    # Custom expression language parsed separately
+    when = <<-EXPR
+      detect_sqli(normalize(request.args))
+      or detect_sqli(normalize(request.body))
+    EXPR
+
+    action = "block"
+
+    effects {
+      tx_sqli_score    = "+=5"
+      tx_anomaly_score = "+=5"
+      capture          = true
+    }
+  }
+}
+```
+
+**Strengths:**
+- HCL handles the hard parts: block parsing, heredocs, interpolation, error recovery
+- Custom expression parser is small (only boolean + function calls + field refs)
+- HCL heredoc syntax (`<<-EXPR ... EXPR`) cleanly embeds multi-line expressions
+- Macros can be HCL blocks that the compiler processes
+- Editor support: HCL highlighting works for structure; expression highlighting
+  could be layered
+
+**Weaknesses:**
+- Two parsers, two grammars, two mental models
+- Conditions as heredoc strings lose HCL-level type checking
+- Macros are HCL blocks (declarative list of steps) rather than composable expressions
+- More complex build: HCL dependency + custom parser code
+
+## Comparison Matrix
+
+| | HCL (A) | HCL+CEL (B) | HCL+Expr (C) | Custom (D) | HCL+Custom (E) |
+|---|---|---|---|---|---|
+| **Block structure** | Native | HCL | HCL | Must build | HCL |
+| **Condition syntax** | `f(g(x)) && h(y)` | `x.g().f() && y.h()` | `f(g(x)) && h(y)` | `x \|> g() \|> f() and y \|> h()` | Custom in heredoc |
+| **Pipeline** | No | Method chain | No | Native `\|>` | Possible in custom |
+| **User macros** | Go functions only | CEL macros (AST) | Go functions only | Language-level | HCL blocks + Go |
+| **Globals/groups** | Native blocks | HCL blocks | HCL blocks | Must build | HCL blocks |
+| **Go dependency** | `hcl/v2` (MPL) | `hcl/v2` + `cel-go` (Apache) | `hcl/v2` + `expr` (MIT) | None | `hcl/v2` (MPL) |
+| **WASM size** | Medium | Large | Medium | Small | Medium |
+| **Editor support** | Terraform ecosystem | Partial | Partial | Must build | Partial |
+| **Learning curve** | Low (Terraform users) | Medium (two syntaxes) | Low-Medium | Medium (new syntax) | Medium (two layers) |
+| **Sprig/function libs** | Direct integration | Via CEL functions | Via Expr functions | Must wrap | Direct for HCL parts |
+| **Effects syntax** | String values (`"+=5"`) | String values | String values | Native (`+= 5`) | String values |
+| **Condition prominence** | Attribute value | String attribute | String attribute | `when`/`then` keywords | Heredoc block |
+| **Type checking** | HCL schema | CEL type system | Expr type system | Custom | Split |
+| **Maintenance cost** | Low | Medium | Low-Medium | Medium-High | Medium |
+
+## Key Trade-Off Analysis
+
+### The Nesting Question (With Macros)
+
+With named composition functions, the nesting concern largely dissolves:
+
+```hcl
+# HCL: 1-2 levels of nesting — readable
+condition = detect_sqli(normalize(request.args))
+condition = detect_xss(normalize(request.headers["User-Agent"]))
+
+# vs. Custom: pipeline — also readable
+when request.args |> normalize() |> detect_sqli()
+when request.headers["User-Agent"] |> normalize() |> detect_xss()
+```
+
+Both are acceptable. The pipeline is more readable for ad-hoc transform chains that
+are not yet captured in a macro, but macros are the steady state for mature rulesets.
+
+### The Effects Block Problem
+
+HCL's attribute syntax does not naturally express side-effect operations:
+
+```hcl
+# Awkward: operations encoded as strings
+effects {
+  tx_anomaly_score = "+=5"     # Is this assignment or string?
+  capture          = true       # Ok
+  log_audit        = true       # Ok
+}
+
+# Or: structured but verbose
+effect "setvar" {
+  target = "tx.anomaly_score"
+  op     = "+="
+  value  = 5
+}
+```
+
+A custom parser handles this natively:
+
+```
+then block {
+  tx.anomaly_score += 5
+  capture()
+  log(audit: true)
+}
+```
+
+This is a genuine advantage of the custom parser — effect blocks are imperative
+statements, and HCL is not designed for imperative code.
+
+### The Two-Parser Problem (Options B, C, E)
+
+Hybrid approaches add complexity:
+- Two grammars to document and maintain
+- Editor support must understand both layers
+- Error messages cross parser boundaries ("HCL parsed fine, but the CEL expression
+  on line 15 has a type error")
+- Macro definitions live in one syntax but are invoked in another
+
+This is manageable but adds friction. A single-parser approach (A or D) is simpler.
+
+### The Maintenance Argument
+
+HCL's parser is maintained by HashiCorp. A custom parser must be maintained by the
+CRSLang team. For a small team, this is a real cost — but the grammar is small (~30
+productions) and well-understood. The total parser code is estimated at 1500-2500 lines
+of Go, comparable to a medium-sized package.
+
+## Decision
+
+**Deferred.** This ADR presents the analysis; the decision depends on the team's
+priorities:
+
+**Choose HCL (Option A) if:**
+- Minimizing parser maintenance is the top priority
+- The team values Terraform-ecosystem familiarity
+- Macros defined in Go (not in the language) are acceptable
+- The effects block can use structured sub-blocks instead of imperative syntax
+- Sprig / existing function library integration is important
+
+**Choose Custom Parser (Option D) if:**
+- The pipeline operator is valued even with macros available
+- Language-level macro definitions are desired (users define macros in `.crs` files)
+- Native `when`/`then` structure and imperative effects matter
+- The team is comfortable maintaining a small parser
+- Full control over language evolution is important
+
+**Avoid the hybrid options (B, C, E)** unless there is a compelling reason to split
+the parser. The added complexity of two grammars outweighs the benefits for a language
+this small.
+
+### Regardless of Choice
+
+Some design elements are constant across all options:
+
+1. **Globals block** — inherited by all rules (version, common tags)
+2. **Group blocks** — file-level or logical grouping with inherited tags/metadata
+3. **Named function compositions** — whether Go-registered (HCL) or language-level
+   (custom), reusable transform chains are essential
+4. **SecLang import** — the ANTLR-based importer remains unchanged
+5. **YAML serialization** — the IR can always be exported to YAML
+6. **WASM/playground** — all options compile to WASM
+
+## Consequences
+
+### If HCL Is Chosen
+
+- ADR-0005 is superseded; no custom parser needed
+- Pipeline operator (ADR-0002) is dropped from the text syntax; macros replace it
+- Effects (ADR-0004) must be redesigned for HCL's declarative attribute model
+- The function registry becomes the primary extension point
+- Sprig and other Go function libraries can be integrated directly
+- Editor support comes largely for free (HCL plugins exist)
+
+### If Custom Parser Is Chosen
+
+- ADR-0005 stands as designed
+- Pipeline, macros, effects all work as proposed in earlier ADRs
+- Must build editor support (Tree-sitter grammar, LSP)
+- Function library must be built from scratch (no Sprig shortcut)
+- More initial investment, more long-term control

--- a/docs/adr/0009-language-base-evaluation.md
+++ b/docs/adr/0009-language-base-evaluation.md
@@ -170,7 +170,8 @@ etc.) for free.
 - `effects` block uses string values for operations (`"+=5"`) because HCL attributes
   are assignments, not arbitrary statements
 - No `let` bindings in expressions for data-flow dependencies (ADR-0003 Category 3)
-- HCL variable references use `var.name` prefix which would need custom handling
+- HCL itself does not require a `var.` prefix, but Terraform-style variable namespaces
+  would need custom handling or a CRSLang-specific naming model
 
 **Pipeline workaround with Go templates:**
 

--- a/docs/adr/0010-multi-target-compilation.md
+++ b/docs/adr/0010-multi-target-compilation.md
@@ -104,8 +104,9 @@ rule 100001 {
 }
 
 # Compiled SecLang: two rules, same score target
-SecRule ... "id:100001a,...,setvar:'tx.anomaly_score=+5'"
-SecRule ... "id:100001b,...,setvar:'tx.anomaly_score=+5'"
+# Rule IDs must be integers; the compiler allocates adjacent IDs deterministically.
+SecRule ... "id:1000011,...,setvar:'tx.anomaly_score=+5'"
+SecRule ... "id:1000012,...,setvar:'tx.anomaly_score=+5'"
 ```
 
 **Macros / named compositions** — expanded inline during compilation. The compiled

--- a/docs/adr/0010-multi-target-compilation.md
+++ b/docs/adr/0010-multi-target-compilation.md
@@ -1,0 +1,211 @@
+# ADR-0010: Multi-Target Compilation Model
+
+- **Status:** Proposed
+- **Date:** 2026-04-15
+- **Phase:** 0 (foundational — shapes language design constraints)
+
+## Context
+
+CRSLang's primary compilation target today is SecLang (ModSecurity/Coraza `.conf` files).
+However, the long-term vision is to compile CRSLang rules to multiple WAF engines:
+
+| Target | Expression language | Organization |
+|--------|-------------------|--------------|
+| ModSecurity / Coraza | SecLang directives | OWASP |
+| Google Cloud Armor | CEL expressions | Google Cloud |
+| AWS WAF | JSON rule statements | AWS |
+| Cloudflare WAF | Wirefilter expressions | Cloudflare |
+
+Each target has a different expression language, different capabilities, and different
+limitations. CRSLang must be expressive enough to author rules once and compile them to
+any supported target.
+
+### The Constraint Question
+
+Should CRSLang be constrained to the intersection of what all targets support? Or should
+it be a superset, with per-target compilation producing errors or warnings for
+unsupported features?
+
+CRSLang v1 was constrained by SecLang — it modeled SecLang concepts directly (chains,
+phases, transformation lists, action bags). This made SecLang round-tripping lossless but
+prevented the language from expressing anything SecLang couldn't.
+
+## Decision
+
+**CRSLang is not constrained by any single compilation target.** The language expresses
+the full range of WAF detection logic. Each compilation backend maps as much as it can
+and reports clear errors for unsupported features.
+
+### Design Principles
+
+1. **Language over target** — CRSLang's syntax and semantics are defined by what makes
+   rules readable and composable, not by what a specific engine supports.
+
+2. **SecLang generation must be lossless for the CRS ruleset** — the entire OWASP CRS
+   must compile to SecLang without loss. This is a practical constraint (CRS deploys on
+   ModSecurity/Coraza today), not a language constraint.
+
+3. **Graceful degradation** — when a CRSLang feature has no equivalent in a target:
+   - If there's a workaround (e.g., OR → multiple rules with scoring for SecLang),
+     the compiler applies it automatically.
+   - If there's no workaround, the compiler emits a clear error: "Feature X is not
+     supported by target Y."
+   - Rules that use unsupported features are flagged, not silently dropped.
+
+4. **Target capability profiles** — each backend declares what it supports. Tooling can
+   validate a ruleset against a target before compilation.
+
+### Compilation Architecture
+
+```
+                            ┌──► SecLang (.conf)
+                            │
+CRSLang (.crs) ──► IR ─────┼──► Cloud Armor (CEL)
+                            │
+                            ├──► AWS WAF (JSON)
+                            │
+                            └──► Cloudflare (Wirefilter)
+```
+
+The IR (intermediate representation) is the shared substrate. It is richer than any
+single target. Compilation backends are independent — adding a new target does not affect
+existing backends or the language itself.
+
+### Feature Support Matrix (Expected)
+
+| Feature | SecLang | Cloud Armor | AWS WAF | Cloudflare |
+|---------|---------|-------------|---------|------------|
+| Boolean AND | chain (workaround) | native | native | native |
+| Boolean OR | separate rules (workaround) | native | native | native |
+| Regex matching | native | native | native | native |
+| String transforms | native (40+) | limited | very limited | limited |
+| IP matching | native | native | native | native |
+| Anomaly scoring | via TX variables | not native | not native | not native |
+| `detect_sqli()` | native (libinjection) | not available | managed rules | managed rules |
+| `detect_xss()` | native (libinjection) | not available | managed rules | managed rules |
+| Response body inspection | native | not available | not available | limited |
+| `ctl:` runtime overrides | native | not available | not available | not available |
+| File-based pattern lists | native (`@pmFromFile`) | not available | not available | not available |
+| Rule exclusions | native | custom | custom | custom |
+
+### SecLang-Specific Considerations
+
+Because SecLang is the primary target and has the most constraints, the compiler must
+handle several CRSLang features that SecLang cannot express directly:
+
+**Boolean OR** — CRSLang's `A or B` has no SecLang equivalent. The compiler decomposes
+it into separate rules with shared scoring:
+
+```
+# CRSLang
+rule 100001 {
+  when condition_a or condition_b
+  then block { tx.anomaly_score += 5 }
+}
+
+# Compiled SecLang: two rules, same score target
+SecRule ... "id:100001a,...,setvar:'tx.anomaly_score=+5'"
+SecRule ... "id:100001b,...,setvar:'tx.anomaly_score=+5'"
+```
+
+**Macros / named compositions** — expanded inline during compilation. The compiled
+SecLang contains the full transformation chain.
+
+**Phase inference** — resolved to a numeric phase value in the SecLang output.
+
+**Typed fields** — mapped back to SecLang variable/collection names.
+
+**First-class scoring** — expanded to `setvar` actions in SecLang.
+
+### File Organization Metadata
+
+CRS rules are organized into specific `.conf` files with a defined loading order
+(REQUEST-901-INITIALIZATION.conf, REQUEST-920-PROTOCOL-ENFORCEMENT.conf, etc.). This
+file structure matters for SecLang deployment because ModSecurity loads files in
+order.
+
+CRSLang preserves file organization as metadata in the IR. When compiling to SecLang,
+the compiler emits rules into the correct files. When compiling to other targets that
+don't have file-order dependencies, this metadata is ignored.
+
+### Testing Strategy
+
+Two testing layers support the multi-target model:
+
+1. **Language-level tests** — validate CRSLang rules directly against the IR, without
+   compilation. Check conditions, scoring, field access, type safety. Fast, no engine
+   needed.
+
+2. **E2E / integration tests** — compile to a target format (`.conf`, CEL, etc.),
+   deploy to the engine, run `ftw` or equivalent test framework. Validates that
+   compilation output works in the real engine. Essential for SecLang, where the
+   compilation involves workarounds (OR decomposition, chain reconstruction).
+
+Both layers are necessary. Language-level tests catch rule logic errors. E2E tests
+catch compilation and engine-specific issues.
+
+## Alternatives Considered
+
+### A: Constrain to SecLang's capabilities
+
+Limit CRSLang to what SecLang can express. No OR, no macros, no features beyond what
+compiles 1:1.
+
+**Rejected because:**
+- Defeats the purpose of a new language
+- Cloud WAF targets natively support OR, grouping, and richer expressions
+- CRS maintainers cannot express patterns they can think of
+- The language becomes a thin skin over SecLang rather than an improvement
+
+### B: Constrain to the intersection of all targets
+
+Limit CRSLang to features supported by every target.
+
+**Rejected because:**
+- The intersection is too small (string transforms, regex, IP matching, basic AND)
+- Cloud WAF targets have very different capabilities
+- Would prevent CRS from using features like `detect_sqli()` which only some engines
+  support
+- New targets could further shrink the intersection
+
+### C: Per-target language profiles
+
+Define subsets of CRSLang for each target (e.g., "CRSLang-SecLang", "CRSLang-CEL").
+
+**Rejected because:**
+- Fragments the language and the community
+- Rule authors must know which profile they're writing for
+- Tooling must handle multiple profiles
+- Defeats the "write once" goal
+
+## Consequences
+
+### Positive
+
+- CRSLang can express any WAF detection pattern, not just SecLang patterns
+- New targets can be added without changing the language
+- Rules that work on all targets are portable by default
+- Target capability profiles enable early validation
+- CRS can eventually deploy to cloud WAFs without manual translation
+
+### Negative
+
+- Compiler complexity increases with each target
+- Feature support matrix must be maintained and documented
+- Rule authors who care about portability must check target compatibility
+- SecLang workarounds (OR decomposition) may produce less efficient output than
+  hand-written SecLang
+
+### Risks
+
+- **SecLang workaround correctness** — decomposing OR into multiple rules changes
+  evaluation semantics (each rule is independent, not short-circuited). Must validate
+  that the decomposed output is semantically equivalent.
+- **Target drift** — cloud WAF targets change their expression languages over time.
+  Compilation backends must be maintained per-target.
+- **CRS adoption** — if CRS rules use features that only compile to SecLang (e.g.,
+  `detect_sqli()`), the "write once" promise is weakened. Document which features are
+  portable vs target-specific.
+- **Performance** — compiler workarounds may produce less optimized output than native
+  rules. For SecLang, measure the impact of OR decomposition on rule evaluation
+  performance.

--- a/docs/adr/0011-first-class-scoring.md
+++ b/docs/adr/0011-first-class-scoring.md
@@ -1,0 +1,298 @@
+# ADR-0011: First-Class Scoring Model
+
+- **Status:** Proposed
+- **Date:** 2026-04-15
+- **Phase:** 3 (part of structured actions redesign)
+
+## Context
+
+CRS uses an anomaly scoring model where rules accumulate scores rather than blocking
+immediately. Each attack detection rule adds to a total anomaly score and a
+category-specific score. A separate evaluation rule in a later phase checks whether the
+accumulated score exceeds a threshold and takes action.
+
+Today, this is implemented as manual TX variable manipulation in every rule:
+
+```
+SecRule REQUEST_ARGS "@detectSQLi" \
+    "id:942100,\
+    phase:2,\
+    block,\
+    capture,\
+    t:none,t:urlDecodeUni,t:lowercase,\
+    msg:'SQL Injection Attack Detected',\
+    severity:'CRITICAL',\
+    setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+```
+
+The score values are indirectly derived from severity — `tx.critical_anomaly_score` is
+set to `5` in `crs-setup.conf`, `tx.warning_anomaly_score` to `3`, etc. But this
+indirection is manual wiring: every rule must include the correct `setvar` actions with
+the correct TX variable reference for its severity level.
+
+### Problems
+
+1. **Boilerplate** — every attack detection rule has 2-3 `setvar` actions for scoring.
+   This is the single largest source of repetition in CRS rules.
+2. **Error-prone** — using the wrong score variable (`tx.warning_anomaly_score` instead
+   of `tx.critical_anomaly_score`) for a CRITICAL severity rule is a silent bug.
+3. **Indirection** — the severity-to-score mapping is defined in `crs-setup.conf` as TX
+   variables, then referenced via `%{tx.critical_anomaly_score}` interpolation in every
+   rule. The relationship between severity and score is not explicit.
+4. **Category scores are manual** — whether a rule increments `tx.sql_injection_score`
+   or `tx.xss_score` depends on the rule author remembering to add the right `setvar`.
+5. **Not toolable** — scoring analysis (which rules contribute how much to the total
+   score, what thresholds are configured) requires parsing `setvar` strings.
+
+## Decision
+
+Make anomaly scoring a **first-class language concept**. Scoring is derived from severity
+and category, with explicit override capability.
+
+### Severity-Derived Scoring
+
+When a rule declares a severity, scoring happens automatically:
+
+```
+rule 942100 (severity: critical) {
+  when request.args |> detect_sqli()
+  then block
+}
+```
+
+The compiler derives the score from the severity using a scoring table defined in
+globals:
+
+```
+globals {
+  scoring {
+    critical = 5
+    warning  = 3
+    notice   = 2
+  }
+}
+```
+
+This rule automatically contributes `5` to the anomaly score because it has
+`severity: critical` and the scoring table maps critical to 5.
+
+### Category Scoring via Groups
+
+Category-specific scores (SQL injection, XSS, RCE, etc.) are derived from the group
+a rule belongs to:
+
+```
+group "sql_injection" {
+  category = "sqli"
+
+  rule 942100 (severity: critical) {
+    when request.args |> detect_sqli()
+    then block
+  }
+
+  rule 942110 (severity: critical) {
+    when request.args |> detect_sqli()
+    then block
+  }
+}
+```
+
+Rules in this group automatically increment both `anomaly_score` and `sqli_score` by the
+severity-derived value. No `setvar` needed.
+
+### Explicit Score Override
+
+For rules that need non-standard scoring, an explicit `score()` function is available:
+
+```
+rule 920170 (severity: warning) {
+  when request.method |> matches("^(?:GET|HEAD)$")
+   and request.headers["Content-Length"] |> not(matches("^0?$"))
+  then block {
+    score(anomaly: 5, protocol: 3)  # override severity-derived scores
+  }
+}
+```
+
+### Paranoia Levels
+
+CRS paranoia levels (PL1-PL4) control which rules are active and which score bucket
+they contribute to (`tx.inbound_anomaly_score_pl1` through `pl4`). In the new model,
+paranoia level is a rule attribute:
+
+```
+rule 942100 (severity: critical, paranoia: 1) {
+  when request.args |> detect_sqli()
+  then block
+}
+
+rule 942101 (severity: critical, paranoia: 2) {
+  when request.args |> url_decode() |> detect_sqli()
+  then block
+}
+```
+
+The compiler uses the paranoia attribute to:
+1. Determine which PL score bucket to increment (for SecLang output)
+2. Determine whether the rule is active at a given paranoia level
+3. Generate the appropriate skip/marker logic for SecLang
+
+### Scoring Evaluation
+
+The scoring evaluation rule (currently rule 949110/959100 in CRS) becomes a built-in
+concept rather than a hand-written rule:
+
+```
+# Defined in globals or as a special directive
+scoring_threshold {
+  inbound  = 5    # was: tx.inbound_anomaly_score_threshold
+  outbound = 4    # was: tx.outbound_anomaly_score_threshold
+  action   = deny(status: 403)
+}
+```
+
+This replaces the complex phase-5 evaluation rules in CRS that manually compare
+accumulated scores against thresholds.
+
+### Compilation to SecLang
+
+The compiler expands first-class scoring to SecLang `setvar` actions:
+
+```
+# CRSLang
+rule 942100 (severity: critical, paranoia: 1) {
+  when request.args |> detect_sqli()
+  then block
+}
+
+# Compiled SecLang
+SecRule REQUEST_ARGS "@detectSQLi" \
+    "id:942100,\
+    phase:2,\
+    block,\
+    t:none,\
+    severity:'CRITICAL',\
+    setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\
+    setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
+```
+
+The `scoring {}` globals compile to TX variable initialization in `crs-setup.conf`.
+The `scoring_threshold {}` compiles to the evaluation rules in phases 3-5.
+
+### Compilation to Other Targets
+
+For targets that don't have native anomaly scoring (Cloud Armor, AWS WAF, Cloudflare):
+- Each rule becomes a standalone rule in the target format
+- The scoring model is either:
+  - Emulated via target-specific mechanisms (if available)
+  - Simplified to direct block/allow (each rule acts independently)
+  - Documented as a limitation of the target
+
+### IR Representation
+
+```go
+type ScoringConfig struct {
+    Levels    map[Severity]int     // critical: 5, warning: 3, notice: 2
+    Threshold ScoringThreshold
+}
+
+type ScoringThreshold struct {
+    Inbound  int
+    Outbound int
+    Action   DisruptiveAction
+}
+
+type RuleMetadata struct {
+    ID       int
+    Severity Severity        // critical, warning, notice
+    Paranoia int             // 1-4
+    Category string          // "sqli", "xss", "rce", etc. (from group)
+    // ... other metadata
+}
+
+// Explicit score override in effects
+type ScoreEffect struct {
+    Scores map[string]int   // anomaly: 5, protocol: 3, etc.
+}
+```
+
+## Alternatives Considered
+
+### A: Keep scoring as TX variable manipulation
+
+Leave `setvar` in effect blocks, just make the syntax nicer:
+
+```
+then block {
+  tx.anomaly_score += 5
+  tx.sqli_score += 5
+}
+```
+
+**Rejected because:**
+- Still boilerplate in every rule
+- Still error-prone (wrong score value for severity)
+- Still not toolable for score analysis
+- ADR-0004 already has this syntax as the baseline; this ADR builds on it
+
+### B: Score as a named effect only (no severity derivation)
+
+```
+then block {
+  score(anomaly: 5, sqli: 5)
+}
+```
+
+**Rejected as the only mechanism because:**
+- Still requires every rule to declare its scores
+- The severity-to-score mapping is the entire point — it's a policy, not a per-rule
+  decision
+- Explicit `score()` is kept as an override mechanism
+
+### C: Score as rule metadata only (no explicit override)
+
+```
+rule 942100 (severity: critical, category: sqli) {
+  when ...
+  then block  # scoring is 100% automatic
+}
+```
+
+**Rejected because:**
+- Some rules legitimately need non-standard scoring
+- No escape hatch for edge cases
+- Too rigid for the full CRS ruleset
+
+## Consequences
+
+### Positive
+
+- Eliminates 2-3 `setvar` actions from every attack detection rule (~80% of CRS rules)
+- Severity-to-score mapping is a single configuration, not scattered across hundreds of
+  rules
+- Category scoring is automatic from group membership
+- Paranoia levels become a typed attribute, not a naming convention
+- Scoring analysis becomes trivial (query the IR for severity/category/paranoia)
+- Score threshold configuration is a single declaration, not a complex evaluation rule
+- Compile-time validation: severity is required on attack rules, preventing missing scores
+
+### Negative
+
+- Rules that deviate from the standard scoring model need the `score()` override, which
+  mixes two scoring mechanisms (implicit + explicit)
+- Paranoia levels as a language concept may not map to all target engines
+- The scoring evaluation rule (949110/959100) becomes compiler-generated, which means
+  debugging it requires understanding the compiler output
+
+### Risks
+
+- **Scoring model flexibility** — CRS's scoring model may evolve (new score categories,
+  different threshold logic). The language must be flexible enough to accommodate changes
+  without breaking existing rules.
+- **Target compatibility** — anomaly scoring is fundamentally a ModSecurity/Coraza
+  concept. Other targets may handle scoring differently or not at all. The multi-target
+  compilation model (ADR-0010) must define how scoring degrades per target.
+- **Migration** — converting existing CRS rules from manual `setvar` to severity-derived
+  scoring requires validating that the derived scores match the original. An automated
+  migration tool should compare outputs.

--- a/docs/adr/0011-first-class-scoring.md
+++ b/docs/adr/0011-first-class-scoring.md
@@ -14,7 +14,7 @@ accumulated score exceeds a threshold and takes action.
 Today, this is implemented as manual TX variable manipulation in every rule:
 
 ```
-SecRule REQUEST_ARGS "@detectSQLi" \
+SecRule ARGS "@detectSQLi" \
     "id:942100,\
     phase:2,\
     block,\
@@ -167,10 +167,11 @@ rule 942100 (severity: critical, paranoia: 1) {
 }
 
 # Compiled SecLang
-SecRule REQUEST_ARGS "@detectSQLi" \
+SecRule ARGS "@detectSQLi" \
     "id:942100,\
     phase:2,\
     block,\
+    capture,\
     t:none,\
     severity:'CRITICAL',\
     setvar:'tx.sql_injection_score=+%{tx.critical_anomaly_score}',\

--- a/docs/adr/0011-first-class-scoring.md
+++ b/docs/adr/0011-first-class-scoring.md
@@ -141,16 +141,23 @@ The compiler uses the paranoia attribute to:
 ### Scoring Evaluation
 
 The scoring evaluation rule (currently rule 949110/959100 in CRS) becomes a built-in
-concept rather than a hand-written rule:
+concept rather than a hand-written rule. The thresholds are **deployment policy** and
+live in the `config {}` block defined by [ADR-0012](0012-ruleset-initialization.md):
 
 ```
-# Defined in globals or as a special directive
-scoring_threshold {
-  inbound  = 5    # was: tx.inbound_anomaly_score_threshold
-  outbound = 4    # was: tx.outbound_anomaly_score_threshold
-  action   = deny(status: 403)
+# Deployment policy — in config {} (ADR-0012)
+config {
+  scoring {
+    inbound_threshold  = 5    # was: tx.inbound_anomaly_score_threshold
+    outbound_threshold = 4    # was: tx.outbound_anomaly_score_threshold
+    action             = deny(status: 403)
+  }
 }
 ```
+
+The scoring severity table (`globals { scoring {} }`) remains a ruleset constant —
+it maps severity levels to point values and is not deployer-tunable. Only the
+thresholds and evaluation action belong in `config {}`.
 
 This replaces the complex phase-5 evaluation rules in CRS that manually compare
 accumulated scores against thresholds.
@@ -178,8 +185,9 @@ SecRule ARGS "@detectSQLi" \
     setvar:'tx.inbound_anomaly_score_pl1=+%{tx.critical_anomaly_score}'"
 ```
 
-The `scoring {}` globals compile to TX variable initialization in `crs-setup.conf`.
-The `scoring_threshold {}` compiles to the evaluation rules in phases 3-5.
+The `globals { scoring {} }` block compiles to TX variable initialization in the
+generated init block (see ADR-0012). The `config { scoring {} }` thresholds compile
+to the evaluation rules in phases 3-5, also via the generated init block.
 
 ### Compilation to Other Targets
 
@@ -193,11 +201,12 @@ For targets that don't have native anomaly scoring (Cloud Armor, AWS WAF, Cloudf
 ### IR Representation
 
 ```go
-type ScoringConfig struct {
-    Levels    map[Severity]int     // critical: 5, warning: 3, notice: 2
-    Threshold ScoringThreshold
+// Ruleset constant — from globals { scoring {} }
+type ScoringLevels struct {
+    Levels map[Severity]int     // critical: 5, warning: 3, notice: 2
 }
 
+// Deployment policy — from config { scoring {} } (ADR-0012)
 type ScoringThreshold struct {
     Inbound  int
     Outbound int

--- a/docs/adr/0012-ruleset-initialization.md
+++ b/docs/adr/0012-ruleset-initialization.md
@@ -1,0 +1,321 @@
+# ADR-0012: Ruleset Initialization and Deployment Configuration
+
+- **Status:** Proposed
+- **Date:** 2026-04-25
+- **Phase:** 0 (resolves the open risk in ADR-0008; precedes Phase 3 scoring work in ADR-0011)
+
+## Context
+
+CRS uses a two-layer initialization chain that predates any notion of a composable rule
+language:
+
+1. **`crs-setup.conf`** — a SecLang file the deployer edits. It uses `SecAction` with
+   `setvar` to push deployment policy into TX variables: paranoia level, anomaly score
+   thresholds, allowed HTTP methods, allowed content types, argument length limits, and
+   similar detection parameters.
+
+2. **901 rules** — hand-authored SecLang rules that run at request time (phase 1) to:
+   - Verify `crs-setup.conf` was loaded (rule 901001 checks `&TX:crs_setup_version`)
+   - Initialize scoring TX variables (`tx.critical_anomaly_score = 5`, etc.)
+   - Propagate the paranoia level from TX into the skip/marker machinery
+   - Initialize defaults for any config variable the deployer did not set
+
+This design is a consequence of SecLang having no compile-time constants. Everything is a
+runtime TX variable. CRSLang v2 has no such constraint.
+
+### Problems
+
+1. **Runtime init for compile-time policy** — paranoia level, scoring thresholds, and
+   allowed methods do not change between requests. They are deployment policy. Expressing
+   them as runtime `setvar` instructions is an artifact of the SecLang model, not a
+   design choice.
+
+2. **Boilerplate rules** — the 901 block exists solely to wire configuration into the rule
+   engine. None of these rules contain detection logic. They are infrastructure, and
+   infrastructure should be compiler-generated.
+
+3. **Sanity check as a rule** — rule 901001 checks that `crs-setup.conf` was loaded. This
+   is a workaround for SecLang's lack of include-time validation. A compiler or loader can
+   enforce this guarantee statically.
+
+4. **Split across two files** — deployment policy (crs-setup.conf) and runtime init (901
+   rules) are separate files that must stay in sync. Adding a new config parameter
+   requires touching both.
+
+5. **TX variables as a configuration API** — parameters like `tx.allowed_methods` are TX
+   variables that rules read as if they were static data. This works but loses type
+   information, validates nothing at load time, and makes the configuration API implicit
+   rather than declared.
+
+### Scope Relative to ADR-0008
+
+ADR-0008 draws the line between engine configuration (out of scope: body size limits,
+PCRE limits, log paths) and rule-adjacent concerns (in scope: defaults, markers,
+signatures). It notes in its Risks section that `crs-setup.conf` "is a mix of
+configuration directives and `SecAction` rules that initialize TX variables" and defers
+the question of what replaces the TX-initializing part.
+
+This ADR resolves that deferred question. It defines the `config {}` block as the
+replacement for crs-setup.conf's detection policy parameters and the 901 init rules.
+
+## Decision
+
+CRSLang introduces a **`config {}` block** that holds user-tunable deployment policy.
+The compiler generates all necessary SecLang initialization from this block — no
+hand-authored 901 rules, no two-file split.
+
+### Separation of Concerns
+
+Four distinct concepts that were previously conflated:
+
+| Block | Defined by | Changed by | Examples |
+|-------|-----------|------------|---------|
+| `globals {}` | Ruleset authors | Nobody — read-only | Scoring severity table, component version |
+| `config {}` | Ruleset authors (defaults) | Deployers (overrides) | Paranoia level, allowed methods, thresholds |
+| `defaults {}` | Ruleset authors | Deployers (rarely) | Default action, default log behavior |
+| Rule metadata | Rule authors | Nobody after authoring | `severity:`, `paranoia:`, `phase:` |
+
+`globals {}` is ruleset policy — it defines the scoring model and is the same for every
+deployment. `config {}` is deployment policy — it is the tunable surface the deployer
+is expected to edit.
+
+### The `config {}` Block
+
+```
+config {
+  # Which rules are active (ADR-0011: paranoia: N attribute on rules uses this)
+  paranoia_level = 1
+
+  # Anomaly mode: accumulate scores and evaluate at end of phase.
+  # immediate: each rule blocks independently (no scoring evaluation needed).
+  blocking_mode  = anomaly
+
+  # Detection policy — parameters used directly by detection rules
+  allowed_methods       = ["GET", "HEAD", "POST", "OPTIONS"]
+  allowed_content_types = [
+    "application/x-www-form-urlencoded",
+    "multipart/form-data",
+    "text/xml",
+    "application/xml",
+    "application/json",
+  ]
+  allowed_http_versions  = ["HTTP/1.0", "HTTP/1.1", "HTTP/2", "HTTP/3"]
+  restricted_extensions  = [".asa", ".asax", ".ascx", ".axd", ".backup",
+                             ".bak", ".bat", ".cdx", ".cer", ".cfg", ".cmd"]
+  restricted_headers     = ["Proxy-Authorization", "Lock-Token"]
+
+  # Argument limits (rules that enforce sizes reference these)
+  arg_limits {
+    max_num_args      = 255
+    max_arg_name_len  = 100
+    max_arg_value_len = 400
+    max_total_len     = 64000
+  }
+
+  # Upload limits (rules that enforce upload sizes reference these)
+  upload_limits {
+    max_file_size     = 10485760   # 10 MB
+    max_combined_size = 10485760
+  }
+
+  # Anomaly score thresholds — when to block (see ADR-0011 for score model)
+  scoring {
+    inbound_threshold  = 5
+    outbound_threshold = 4
+    action             = deny(status: 403)
+  }
+}
+```
+
+The fields inside `config {}` are defined by the CRS ruleset, not by the CRSLang
+language. The language specifies the block syntax and semantics; CRS defines which
+parameters it supports. A ruleset can declare a schema for its `config {}` parameters
+(types, defaults, documentation), which the compiler uses for validation.
+
+#### Relationship to ADR-0011
+
+ADR-0011 introduced `scoring_threshold {}` as a top-level block. That block is deployment
+policy (different deployments set different thresholds) and belongs in `config {}`. The
+`globals { scoring {} }` block from ADR-0011 remains as-is — it is a ruleset constant,
+not tunable per deployment.
+
+```
+# Ruleset constant — belongs in globals (ADR-0011)
+globals {
+  scoring {
+    critical = 5   # severity to score mapping
+    warning  = 3
+    notice   = 2
+  }
+}
+
+# Deployment policy — belongs in config (this ADR)
+config {
+  scoring {
+    inbound_threshold  = 5
+    outbound_threshold = 4
+    action             = deny(status: 403)
+  }
+}
+```
+
+### 901 Rules Replaced by the Compiler
+
+The hand-authored 901 rules disappear. Each category of init work is handled differently:
+
+| 901 purpose | CRSLang v2 replacement |
+|---|---|
+| Scoring variable init (`tx.critical_anomaly_score = 5`) | Compiler-generated from `globals { scoring {} }` |
+| Score threshold init (`tx.inbound_anomaly_score_threshold = 5`) | Compiler-generated from `config { scoring {} }` |
+| Detection policy init (`tx.allowed_methods = [...]`) | Compiler-generated from `config {}` |
+| Sanity check (`count(tx.crs_setup_version) eq 0 → deny`) | Loader/compiler guarantee (see below) |
+| Paranoia skip propagation | Compiler-generated marker pairs from guarded groups (ADR-0006) |
+| Default init for unset variables | Defaults declared in the config schema; compiler emits defaults |
+
+### Sanity Check Replaced by Loader Guarantee
+
+Rule 901001 detects that `crs-setup.conf` was not included. This check is needed in
+SecLang because the rule engine cannot know at load time whether an include happened.
+
+In CRSLang, the `config {}` block is part of the ruleset itself (or an explicitly
+imported file). The compiler can enforce at compile time that a `config {}` block exists
+and that all required parameters have values. If the deployer forgets to configure, the
+compile fails — no runtime surprise.
+
+For SecLang output, the compiler can emit a version marker in the generated init block
+and omit the runtime sanity check entirely, since correctness is guaranteed before
+deployment.
+
+### Compilation to SecLang
+
+The `config {}` block compiles to a generated initialization block in the SecLang output.
+This generated block replaces both `crs-setup.conf` and the hand-authored 901 rules:
+
+```
+# CRSLang config {} block
+config {
+  paranoia_level = 1
+  allowed_methods = ["GET", "HEAD", "POST", "OPTIONS"]
+  scoring {
+    inbound_threshold = 5
+    action            = deny(status: 403)
+  }
+}
+
+# Compiled SecLang (generated — not hand-authored)
+# ---- CRSLang generated initialization ----
+SecAction \
+    "id:9000001,\
+    phase:1,\
+    nolog,\
+    pass,\
+    setvar:tx.detection_paranoia_level=1,\
+    setvar:tx.allowed_methods=GET HEAD POST OPTIONS,\
+    setvar:tx.critical_anomaly_score=5,\
+    setvar:tx.warning_anomaly_score=3,\
+    setvar:tx.inbound_anomaly_score_threshold=5"
+# ---- end generated initialization ----
+```
+
+The generated IDs occupy a reserved range (e.g., 9000001–9000999) that does not conflict
+with authored rule IDs. Generated comments make the source of the init block clear.
+
+### Workflow: The `setup.crs` Convention
+
+For CRS deployments, the convention is:
+
+```
+crs/
+├── setup.crs         # deployer edits config {} here
+├── rules/
+│   ├── REQUEST-901-INITIALIZATION.crs   # removed — no longer needed
+│   ├── REQUEST-920-PROTOCOL-ENFORCEMENT.crs
+│   └── ...
+└── main.crs          # imports setup.crs and all rule files
+```
+
+`setup.crs` ships as `setup.crs.example` with commented-out defaults. The deployer
+copies and edits it. If no `setup.crs` is provided, the compiler uses the defaults
+declared in the config schema.
+
+The analogy to the current `crs-setup.conf.example` is intentional — the workflow is
+familiar, but the mechanism is now compile-time rather than runtime.
+
+## Alternatives Considered
+
+### A: Keep 901 rules as hand-authored CRSLang rules (status quo structure)
+
+Translate 901 rules from SecLang to CRSLang syntax but keep them as explicit rules:
+
+```
+rule 901001 (phase: request_headers) {
+  when count(tx.crs_setup_version) |> eq(0)
+  then deny(status: 500)
+}
+```
+
+**Rejected because:**
+- The sanity check is a compiler concern, not a rule concern; no CRSLang user should
+  author or read it
+- All other 901 rules are pure boilerplate — translating them from SecLang to CRSLang
+  syntax without conceptual improvement gains nothing
+- The two-file split (setup.crs + 901-init.crs) recreates the crs-setup.conf problem
+  in the new syntax
+
+### B: Separate `setup.crs` file type with its own syntax
+
+A dedicated file type that only allows `config {}` blocks, separate from rule files.
+
+**Rejected because:**
+- `config {}` inside a regular `.crs` file works fine and is simpler
+- A separate file type requires a second parser or parser mode
+- The distinction between "setup file" and "rules file" is a convention, not a language
+  requirement — both use `.crs` extension, with `main.crs` importing `setup.crs`
+
+### C: Runtime TX variables (current model, no change)
+
+Keep `SecAction setvar` as the initialization mechanism, just with nicer CRSLang syntax.
+
+**Rejected because:**
+- Defers policy to runtime unnecessarily
+- The compiler cannot validate configuration values before deployment
+- Rules that read `tx.allowed_methods` are reading runtime state that could be missing
+- The two-file coordination problem persists
+
+### D: Configuration as rule metadata (inline)
+
+Attach deployment policy to the group or ruleset that uses it:
+
+```
+group "protocol_enforcement" (allowed_methods: ["GET", "POST"]) {
+  rule 920170 { ... }
+}
+```
+
+**Rejected because:**
+- Policy that applies across groups (e.g., paranoia level) would be duplicated
+- The deployer cannot easily find and change deployment-wide settings
+- Mixes authoring concerns (which rules exist) with deployment concerns (how they behave)
+
+## Consequences
+
+### Positive
+
+- 901 rules as a file and a concept disappear from CRS authoring
+- `crs-setup.conf` is replaced by a `config {}` block with typed, validated fields
+- Compiler-time validation: missing or invalid config parameters are caught before deployment
+- Deployer workflow stays familiar: copy `setup.crs.example`, edit values
+- Generated SecLang init block is clearly labeled, not confused with hand-authored rules
+- Detection policy parameters are co-located and typed — no more scattered `setvar` strings
+
+### Negative
+
+- Existing CRS users must migrate from `crs-setup.conf` to `setup.crs` (automated migration tool can handle most cases)
+- The config parameter set is defined by the ruleset (CRS), not the language — if CRS adds a new parameter, it must be documented in the schema
+- Generated rule IDs for the init block consume a range that must be reserved and documented
+
+### Risks
+
+- **Config schema versioning** — as CRS evolves, the set of supported `config {}` parameters may change. Deployers upgrading CRS must check whether their `setup.crs` uses deprecated parameters. The compiler should warn on unknown or removed parameters.
+- **Default vs explicit** — if no `setup.crs` is provided, the compiler uses schema defaults. This is safe, but deployers may not realize the defaults are in effect. Clear documentation and a "warn on defaults used" compiler flag mitigate this.
+- **Multi-target config semantics** — some config parameters (e.g., `scoring {}`) may not apply to all compilation targets (Cloud Armor, AWS WAF). The multi-target compiler (ADR-0010) must document which config parameters are target-specific.


### PR DESCRIPTION
Design documentation for evolving CRSLang from a YAML/SecLang serialization into a composable expression language with typed fields, boolean algebra, and function composition.

Includes 9 ADRs covering: language base evaluation (HCL vs custom parser), typed field namespace, phase inference, boolean algebra replacing chains, pipeline operator, structured actions, parser strategy, configuration separation, and rule management directives.