### PR TITLE
docs: add ADRs 0013-0016, TODO.md, and consistency cleanups

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,11 @@
+{
+  // MD040 (fenced-code-language) is disabled because the design docs in docs/
+  // contain CRSLang examples that use bare fences. CRSLang does not exist yet
+  // as a recognized language tag, and labeling these blocks with `text` would
+  // satisfy the linter without adding meaningful value to readers.
+  //
+  // Once CRSLang has a stable spec and editor tooling registers a language
+  // identifier, this can be re-enabled and the fences updated.
+  "default": true,
+  "MD040": false
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,9 +5,22 @@
 CRSLang aims to become a modern, composable rule language for web application firewalls.
 Today it is a YAML serialization of ModSecurity's SecLang AST. The goal is to evolve it
 into a standalone expression language where conditions are composed from typed fields,
-piped through transformation functions, and combined with boolean algebra — similar in
+transformed through composable functions, and combined with boolean algebra — similar in
 spirit to Cloudflare's Wirefilter or Google's CEL, but purpose-built for the CRS
 ecosystem.
+
+## Status
+
+This document and all linked ADRs describe a **proposed** design. No decisions have been
+ratified yet. Every ADR is in `Status: Proposed`. The framing throughout is "the design
+proposes X" rather than "X is decided" — even where the proposed direction reads
+declaratively for clarity.
+
+The most contested open decision is the **language base** (custom parser vs HCL — see
+[ADR-0009](adr/0009-language-base-evaluation.md)), which shapes how Phases 2–4 are
+expressed syntactically. The other Phase 0 ADRs (scope separation, multi-target
+compilation, ruleset initialization) are proposals with reasonable consensus but are
+still subject to revision.
 
 ## Current State
 
@@ -71,7 +84,9 @@ actions:
 
 ## Target State
 
-A rule in the new CRSLang should look like:
+A rule in the new CRSLang should look like (syntax shown uses the custom parser approach;
+the HCL approach expresses the same semantics with named composition functions — see
+Phase 3 and [ADR-0009](adr/0009-language-base-evaluation.md)):
 
 ```
 rule 920170 (severity: warning) {
@@ -91,16 +106,17 @@ the compiler emits `phase:1` automatically.
 Rules that use only cross-phase fields (e.g., `tx.*`) must declare the phase explicitly:
 
 ```
-rule 901001 (phase: request_headers, severity: critical) {
-  when count(tx.crs_setup_version) |> eq(0)
-  then deny(status: 500)
+rule 949110 (phase: logging, severity: critical) {
+  when tx.inbound_anomaly_score |> gt(tx.inbound_anomaly_score_threshold)
+  then deny(status: 403)
 }
 ```
 
 Key properties:
 - **Typed fields** with dot-notation and bracket access for maps
 - **Phase inference** from field types — no redundant phase metadata
-- **Pipeline operator** (`|>`) for chaining transformations and terminal predicates
+- **Composable functions** for chaining transformations and terminal predicates (pipeline
+  operator `|>` if custom parser; named macros if HCL — decided in Phase 0)
 - **Boolean algebra** (`and`, `or`, `not`, parentheses) replacing chains
 - **Structured action blocks** replacing the action bag
 - **Compile-time validation** — phase/field mismatches caught before deployment
@@ -126,41 +142,43 @@ Key properties:
 
 6. **Engine independence** — CRSLang describes *what* to match, not *how* a specific
    engine implements it. Compilation targets (Coraza, ModSecurity, cloud WAFs) are
-   separate concerns. Engine configuration (body limits, PCRE tuning, log paths) is
-   explicitly out of scope — it belongs in engine-specific config files, not in the rule
-   language (see [ADR-0008](adr/0008-configuration-directives.md)).
+   separate concerns. The proposal in [ADR-0008](adr/0008-configuration-directives.md)
+   places engine configuration (body limits, PCRE tuning, log paths) outside the rule
+   language, in engine-specific config files.
 
 ## Evolution Phases
 
 ### Phase 0: Foundational Decisions
 
-Two decisions must be made before any IR or syntax work begins, because they shape
-everything downstream.
+Four foundational topics need to be settled before IR or syntax work begins, because
+they shape everything downstream. The first is genuinely open; the other three have
+proposed directions that are still subject to revision.
 
-**Language base:** Should CRSLang adopt an existing language (HCL, with its Terraform
-ecosystem, Sprig function library, and zero parser maintenance) or build a custom parser
-(with pipeline operator, language-level macros, and full control)? Both approaches
-support globals, groups, named function compositions, and boolean conditions. The key
-trade-off is maintenance cost vs syntactic control — and the answer determines how
-Phases 2-4 are designed.
+**Language base (open):** Should CRSLang adopt an existing language (HCL, with its
+Terraform ecosystem, Sprig function library, and zero parser maintenance) or build a
+custom parser (with pipeline operator, language-level macros, and full control)? Both
+approaches support globals, groups, named function compositions, and boolean conditions.
+The key trade-off is maintenance cost vs syntactic control — and the answer determines
+how Phases 2-4 are designed. ADR-0009 lays out the comparison without picking a winner.
 
-**Scope:** CRSLang describes *what to detect*, not *how to run the engine*. The ~60
-SecLang configuration directives (body limits, PCRE tuning, log paths, etc.) are
-explicitly out of scope. Only rule-adjacent metadata (component signature, default
-actions, markers, app ID) stays in the language.
+**Scope (proposed):** CRSLang would describe *what to detect*, not *how to run the
+engine*. The ~60 SecLang configuration directives (body limits, PCRE tuning, log paths,
+etc.) would move out of scope; only rule-adjacent metadata (component signature, default
+actions, markers, app ID) would stay in the language.
 
-**Multi-target compilation:** CRSLang is not constrained by any single compilation
-target. Today it compiles to SecLang (ModSecurity/Coraza), but the architecture supports
-future backends for Google Cloud Armor (CEL), AWS WAF, Cloudflare (Wirefilter), and
-others. SecLang generation must be lossless for the CRS ruleset. Features that a target
-cannot express are handled by compiler workarounds or clear error messages.
+**Multi-target compilation (proposed):** CRSLang would not be constrained by any single
+compilation target. Today it compiles to SecLang (ModSecurity/Coraza); the proposed
+architecture leaves room for future backends targeting Google Cloud Armor (CEL), AWS WAF,
+Cloudflare (Wirefilter), and others. SecLang generation must remain lossless for the CRS
+ruleset. Features that a target cannot express are handled by compiler workarounds or
+clear error messages.
 
-**Ruleset initialization:** The `crs-setup.conf` + 901 rules two-layer init chain is
-replaced by a `config {}` block that holds user-tunable deployment policy (paranoia
-level, allowed methods, score thresholds, argument limits, etc.). The compiler generates
-all SecLang initialization output — no hand-authored 901 rules, no two-file split. The
-deployer copies `setup.crs.example` and edits it, replacing the current
-`crs-setup.conf.example` workflow.
+**Ruleset initialization (proposed):** The `crs-setup.conf` + 901 rules two-layer init
+chain would be replaced by a `config {}` block that holds user-tunable deployment policy
+(paranoia level, allowed methods, score thresholds, argument limits, etc.). The compiler
+would generate all SecLang initialization output — no hand-authored 901 rules, no
+two-file split. The deployer would copy `setup.crs.example` and edit it, replacing the
+current `crs-setup.conf.example` workflow.
 
 See [ADR-0009: Language Base Evaluation](adr/0009-language-base-evaluation.md),
 [ADR-0008: Separation of Configuration](adr/0008-configuration-directives.md),
@@ -190,8 +208,15 @@ compiler can derive the phase automatically and catch phase/field mismatches at 
 time. Phase is only required as explicit metadata for rules that use exclusively
 cross-phase fields (e.g., `tx.*`).
 
-See [ADR-0001: Typed Field Namespace](adr/0001-typed-field-namespace.md) and
-[ADR-0007: Phase Inference](adr/0007-phase-inference.md).
+Phase 1 also introduces a structured **documentation model** spanning four tiers
+(ruleset, group, rule, rule-management directive), with doc-comments for narrative
+prose and typed metadata fields for machine-readable content (references, FP notes,
+CWE/OWASP tags). Groups nest for conceptual sub-grouping; cross-cutting concepts like
+paranoia and severity get their own documentation blocks.
+
+See [ADR-0001: Typed Field Namespace](adr/0001-typed-field-namespace.md),
+[ADR-0007: Phase Inference](adr/0007-phase-inference.md), and
+[ADR-0013: Documentation Model](adr/0013-documentation-model.md).
 
 ### Phase 2: Boolean Algebra
 
@@ -242,7 +267,7 @@ its severity, and the scoring model (defined in globals) handles the rest.
 |---|---|
 | `disruptive: block` + `setvar: "tx.score=+10"` | `severity: critical` (score auto-derived) |
 | Manual `setvar` per category | Category derived from group membership |
-| Complex phase-5 evaluation rules | `scoring_threshold { inbound = 5 }` |
+| Complex phase-5 evaluation rules | `config { scoring { inbound_threshold = 5 } }` |
 
 Work:
 - Define a `Function` type with signature: name, args, return type
@@ -251,9 +276,15 @@ Work:
 - Redesign actions as structured model (disruptive + effects)
 - `ctl:` directives become `configure {}` blocks
 
+Phase 3 also introduces **macros** for reusable expression compositions (eliminating
+copy-pasted normalization chains and predicate patterns) and **external data sources**
+as first-class typed declarations (IP lists, regex sets, geo databases, regex assemblies).
+
 See [ADR-0002: Pipeline Operator](adr/0002-pipeline-operator.md) (custom parser path),
 [ADR-0004: Structured Action Model](adr/0004-structured-actions.md),
-[ADR-0011: First-Class Scoring](adr/0011-first-class-scoring.md), and
+[ADR-0011: First-Class Scoring](adr/0011-first-class-scoring.md),
+[ADR-0015: Macros and Named Compositions](adr/0015-macros-and-compositions.md),
+[ADR-0016: External Data Sources](adr/0016-external-data-sources.md), and
 [ADR-0009: Language Base Evaluation](adr/0009-language-base-evaluation.md).
 
 ### Phase 4: Text Syntax and Parser
@@ -273,7 +304,13 @@ Work:
 - SecLang import stays via existing ANTLR parser (read-only)
 - Update WASM/playground for the new syntax
 
-See [ADR-0005: Parser Strategy](adr/0005-parser-strategy.md) and
+Phase 4 also formalizes the **import and modularity** model: explicit `import`
+statements, hierarchical namespaces for groups/macros/data, and a single flat namespace
+for rule IDs. Multi-file rulesets gain predictable composition semantics, and packages
+(CRS itself, third-party rule packs) become first-class distribution units.
+
+See [ADR-0005: Parser Strategy](adr/0005-parser-strategy.md),
+[ADR-0014: Imports and Modularity](adr/0014-imports-and-modularity.md), and
 [ADR-0009: Language Base Evaluation](adr/0009-language-base-evaluation.md).
 
 ### Phase 5: Rule Management Directives
@@ -298,8 +335,11 @@ See [ADR-0006: Rule Management Directives](adr/0006-rule-management.md).
 ## Migration Strategy
 
 ```
-Phase 0      Decide language base (HCL vs custom) and scope (no engine config).
-             These decisions gate all subsequent work.
+Phase 0      Settle the four foundational topics: language base (HCL vs custom),
+             scope separation (engine config out of language), multi-target
+             compilation model, and ruleset initialization (config {} block
+             replacing crs-setup.conf + 901 rules). These decisions gate all
+             subsequent work.
 
 Phase 1      Internal IR changes: typed fields, phase inference.
              YAML syntax updated but backward-compatible.
@@ -336,12 +376,20 @@ At every phase:
 | [0012](adr/0012-ruleset-initialization.md) | 0 | Ruleset Initialization and Deployment Configuration | Proposed |
 | [0001](adr/0001-typed-field-namespace.md) | 1 | Typed Field Namespace | Proposed |
 | [0007](adr/0007-phase-inference.md) | 1 | Phase Inference from Field Types | Proposed |
+| [0013](adr/0013-documentation-model.md) | 1 | Documentation Model for Rules, Groups, and Rulesets | Proposed |
 | [0003](adr/0003-boolean-algebra.md) | 2 | Boolean Algebra Replacing Chains | Proposed |
 | [0002](adr/0002-pipeline-operator.md) | 3 | Pipeline Operator for Composition (conditional on 0009) | Proposed |
 | [0004](adr/0004-structured-actions.md) | 3 | Structured Action Model | Proposed |
 | [0011](adr/0011-first-class-scoring.md) | 3 | First-Class Scoring Model | Proposed |
+| [0015](adr/0015-macros-and-compositions.md) | 3 | Macros and Named Compositions | Proposed |
+| [0016](adr/0016-external-data-sources.md) | 3 | External Data Sources | Proposed |
 | [0005](adr/0005-parser-strategy.md) | 4 | Parser Strategy (see 0009 for decision) | Proposed |
+| [0014](adr/0014-imports-and-modularity.md) | 4 | Imports and Modularity | Proposed |
 | [0006](adr/0006-rule-management.md) | 5 | Rule Management Directives | Proposed |
+
+For structural concepts identified but not yet covered by an ADR (time/duration types,
+versioning annotations, function signatures, test attachment, persistent collections,
+capture groups, and others), see [TODO.md](TODO.md).
 
 ## Reference Languages
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,0 +1,196 @@
+# CRSLang Evolution: Open Topics and Future Work
+
+This document tracks structural concepts that have been identified but not yet
+addressed by an ADR. Items are grouped by priority. Each item notes the affected
+existing ADRs, the design questions to answer, and a suggested ADR number when one
+is appropriate to write.
+
+## Status Legend
+
+- **Open** — identified, no ADR yet
+- **Partially covered** — touched by existing ADRs but lacks a dedicated decision
+- **Deferred** — intentionally postponed; adequate workaround exists
+
+## Important Second-Tier (next batch when there's appetite)
+
+### 1. Time and Duration Types — Open
+Proposed: ADR-0017
+
+Need a typed literal for durations (`5m`, `1h`, `30s`) used by:
+- Variable expiry (`expire(tx.var, 3600)` from ADR-0004 — currently raw seconds)
+- Rate-limit windows (when added)
+- Interval-based reload policies (`reload interval: 5m` from ADR-0016)
+- Session/IP collection TTLs
+
+Design questions:
+- Literal syntax: `5m`, `5 minutes`, `Duration("5m")`?
+- Type coercion to/from integer seconds for legacy interop
+- Calendar-aware durations (months, years) — needed or out of scope?
+- Time literals (`2026-04-25`) — separate concern or part of this?
+
+Cross-references: ADR-0004 (effects/expire), ADR-0016 (reload policies).
+
+### 2. Versioning and Lifecycle Annotations — Open
+Proposed: ADR-0018
+
+Rules and groups have lifecycle (added, modified, deprecated, removed). The language
+needs to express this without losing information when rules are renamed or split.
+
+Design questions:
+- Annotation syntax: `@since("4.0")`, `@deprecated("4.5", reason: "...", replacement: rule X)`,
+  `@experimental`?
+- Compile-time warnings on use of deprecated rules?
+- Schema/language-version compatibility — how does a v2 ruleset declare it requires
+  CRSLang spec version N?
+- Migration trail: when rule X is split into X+Y, how is the lineage tracked?
+
+Cross-references: ADR-0006 (rule management), ADR-0013 (documentation), ADR-0014
+(package versioning).
+
+### 3. Function Signatures and Type System — Partially covered
+Proposed: ADR-0019
+
+ADR-0001 types the field namespace. ADR-0015 introduces typed macro signatures. But
+the broader function library (transformations, predicates, custom operators) has no
+documented signature scheme. Without this, "compile-time validation" is partial.
+
+Design questions:
+- Signature declaration syntax for built-in functions?
+- Generic types? (`count<T>(collection<T>) -> int`)
+- Type inference vs explicit annotations
+- Engine-specific function variants (some functions exist on Coraza but not Cloud Armor)
+- How does the type system interact with macros (ADR-0015) and external data
+  (ADR-0016) types?
+
+Cross-references: ADR-0001 (typed fields), ADR-0010 (multi-target — typed function
+availability per target), ADR-0015 (macros), ADR-0016 (data types).
+
+### 4. Test Attachment — Open
+Proposed: ADR-0020 (or rolled into ADR-0013)
+
+Rules need a way to reference their FTW (or successor) test cases. Today FTW lives
+entirely outside the rule language, with cross-references by string rule ID.
+
+Design questions:
+- Where to declare: rule attribute (`tests: "tests/942100.yaml"`), separate `test_file`
+  field, or attached doc-comment section?
+- Inline tests vs sidecar files (preference: sidecar to keep rule files clean)
+- How does the compiler verify test file existence at compile time?
+- Test case format: keep FTW, design a successor, or be format-agnostic?
+
+Cross-references: ADR-0013 (documentation), ADR-0014 (package distribution — tests
+ship with the package).
+
+### 5. Persistent Collections (IP, GLOBAL, SESSION, USER) — Partially covered
+Proposed: ADR-0021
+
+ADR-0001 mentions `ip.*`, `global.*`, `session.*` field prefixes but only for *read*
+access. The *write* side (initcol, setvar with TTL, persistent expiry across requests)
+is not designed. CRS uses these heavily for rate limiting, repeat-offender tracking,
+session-bound state.
+
+Design questions:
+- Initialization: `init_collection(ip: client.ip)` — at rule level or as a setup
+  declaration?
+- TTL semantics: when is a collection variable purged?
+- Cross-engine portability: SecLang has explicit collections; cloud WAFs may model
+  this entirely differently (or not at all)
+- Relationship to TX: TX is per-transaction, collections are persistent — does the
+  syntax distinguish?
+- Collection size limits, eviction policies
+
+Cross-references: ADR-0001 (field namespace), ADR-0003 (boolean algebra has a
+901320 example using initcol), ADR-0010 (multi-target portability).
+
+### 6. Capture Groups and Pattern Bindings — Partially covered
+Proposed: ADR-0022
+
+ADR-0002 mentions `capture()` as a predicate, but how regex captures are accessed
+and composed is not designed. Today's SecLang `TX:0`–`TX:9` is the leak that needs
+replacing.
+
+Design questions:
+- Access syntax: `matched.captures[1]`, `$1`, named captures?
+- Scope: where are captures visible after the predicate that created them?
+- Composition: if rule chain has multiple `matches()` predicates with captures, how
+  do they coexist?
+- Multiple matches: `find_all()` style operations that return a list of captures
+- Backreferences within a regex: who handles them — the regex engine or the language?
+
+Cross-references: ADR-0002 (pipeline operator with `capture()`), ADR-0003 (boolean
+algebra — let bindings option mentioned this).
+
+## Lower Priority (probably fine to defer)
+
+### 7. Custom Operators and Extension Points — Deferred
+
+Plugin system for adding detection algorithms beyond what ships with the engine.
+Engines like Coraza already have plugin systems; the language could acknowledge
+them or ignore them.
+
+Likely resolution: ignore for now; document that engine-specific operators are
+accessed via an `engine_call("operator_name", args)` escape hatch.
+
+### 8. Conditional Compilation — Deferred
+
+`@if(target == "seclang")` for target-specific tweaks. Mostly handled by the
+multi-target compiler (ADR-0010) emitting target-specific output without explicit
+language support. May become important if rule authors need to write target-specific
+fallbacks.
+
+### 9. Conditional Effects — Deferred
+
+`then if (x) { block } else { pass }`. Current binary match-or-don't is probably
+enough. CRS rules don't currently need branched effects.
+
+### 10. Logging Structure — Adequately covered
+
+ADR-0004 has `log()` as an effect. Rich structured logging (audit log enrichment,
+custom fields, log levels per effect) is largely engine-side and out of scope for
+the language.
+
+### 11. Cross-Rule Communication / Signaling — Adequately covered
+
+Beyond TX variables (which already serve this), there's no current need for an
+event/signal model. CRS's existing TX-based communication works; a more formal
+model can wait until a real use case emerges.
+
+### 12. Rate Limiting Primitives — Open but engine-specific
+
+Native syntax for "block if more than N requests from same IP in M minutes." Today
+done via collection state and counters. A first-class rate limit construct would
+be cleaner but is heavily engine-dependent (cloud WAFs have native rate limiting;
+ModSecurity does not).
+
+Likely resolution: model rate limiting as a pattern over collections (covered by
+ADR-0021 once written), not as a dedicated language construct.
+
+### 13. Severity and Category Customization — Open
+
+Examples in earlier ADRs use custom severity values (`critical_payment`). Whether
+authors can define custom severity/category values, and how those interact with
+scoring (ADR-0011), is undecided.
+
+Likely resolution: extend ADR-0011's scoring table to allow custom severities with
+declared point values.
+
+## Cross-Cutting Notes
+
+When writing ADRs from this list, check the following for consistency:
+
+- **Documentation** — every new construct should declare how doc-comments and
+  structured fields apply (ADR-0013)
+- **Imports/Namespacing** — every new declarable entity (data, macro, etc.) lives
+  in a namespace per ADR-0014
+- **Multi-target** — every new feature must declare degradation behavior across
+  ADR-0010's compilation targets
+- **Phase placement** — IR-level concepts go in Phases 1-2; surface syntax in Phase 4
+
+## Conventions
+
+- ADR numbers are reserved when this TODO promises one (e.g., "Proposed: ADR-0017").
+  Numbers are not used elsewhere until the ADR is written.
+- An item moving from "Open" to written ADR is removed from this file and linked
+  from the README ADR table.
+- Items deferred indefinitely stay here as a record of explicit decisions not to
+  pursue.

--- a/docs/adr/0004-structured-actions.md
+++ b/docs/adr/0004-structured-actions.md
@@ -163,20 +163,24 @@ rule 941100 (severity: critical) {
 }
 ```
 
-**Pass with configuration** (setup-style rule, kept for illustrating direct TX
-assignment; note that ADR-0011 lifts `scoring_threshold` and global paranoia settings
-out of rules into a `globals` block):
+**Pass with TX assignment** (illustrative — for setup-style rules, paranoia level and
+score thresholds are no longer authored as TX assignments. Per ADR-0011 the severity
+table is in `globals { scoring {} }`, and per ADR-0012 the deployment thresholds and
+paranoia level are in the `config {}` block. The example below is kept to show direct
+TX assignment syntax for genuine custom-state rules, not as a template for setup):
 ```
 rule 900100 (phase: request_headers) {
   when true
   then pass {
-    tx.paranoia_level = 1
-    tx.anomaly_score_threshold = 5
+    tx.custom_flag = 1
+    tx.request_seen_at = unix_timestamp()
   }
 }
 ```
 
-**Deny with status:**
+**Deny with status** (illustrative example of a TX-only rule; rule 901001 itself is
+compiler-generated per ADR-0012, but the pattern still applies to user-authored
+TX-only rules):
 ```
 rule 901001 (phase: request_headers, severity: critical) {
   when count(tx.crs_setup_version) |> eq(0)

--- a/docs/adr/0007-phase-inference.md
+++ b/docs/adr/0007-phase-inference.md
@@ -53,12 +53,18 @@ Some fields are available in all phases. When a rule uses **only** cross-phase f
 (e.g., only `tx.*` variables), the phase cannot be inferred and must be declared
 explicitly.
 
-In CRS, this pattern appears in:
+In CRS today, this pattern appears in:
 - Initialization rules (phase 1, TX-only) — e.g., rule 901001 checking
   `count(tx.crs_setup_version)`
 - Paranoia level skip rules (phase 1-4, TX-only) — e.g., rules 911011/911012 checking
   `tx.detection_paranoia_level`
 - Scoring evaluation rules (phase 5, TX-only) — evaluating accumulated anomaly scores
+
+Most of these specific patterns are eliminated by other proposals: initialization rules
+become compiler-generated (ADR-0012), paranoia skip rules are replaced by guarded groups
+(ADR-0006), and scoring evaluation is driven by `config { scoring {} }` (ADR-0012). The
+inference rules below still matter for the remaining cases — custom rules that read
+or write TX state across rules, and any cross-phase logic the user authors directly.
 
 ## Decision
 
@@ -107,7 +113,9 @@ rule 920170 {
 ### Explicit Phase Declaration
 
 When inference is not possible (TX-only rules) or when the author wants to override for
-clarity, phase is declared in metadata:
+clarity, phase is declared in metadata. The example below uses rule 901001 as a familiar
+illustration of the inference behavior; in practice 901001 itself is compiler-generated
+per ADR-0012, and explicit phase declaration applies to user-authored TX-only rules:
 
 ```
 # Must declare phase — only TX fields used

--- a/docs/adr/0013-documentation-model.md
+++ b/docs/adr/0013-documentation-model.md
@@ -1,0 +1,434 @@
+# ADR-0013: Documentation Model for Rules, Groups, and Rulesets
+
+- **Status:** Proposed
+- **Date:** 2026-04-25
+- **Phase:** 1 (IR-level concept; surface syntax depends on Phase 0 / Phase 4)
+
+## Context
+
+CRSLang v1's metadata model captures only what SecLang carries: `id`, `phase`, `msg`,
+`severity`, `tags`, `version`, `revision`, `maturity`, plus a free-form `comment` field.
+The IR struct in `types/metadata.go` reflects this directly.
+
+This is enough to round-trip SecLang `.conf` files but not enough to describe a rule's
+*intent*. Substantive per-rule documentation today lives in three disconnected places:
+
+1. **SecLang `#` comments** above each rule — narrative, references, FP notes
+2. **File-level banner comments** at the top of each `.conf` file — describes what the
+   file contains, paranoia coverage, attack family
+3. **External markdown** — the CRS website, `CHANGES.md`, individual ruleset docs
+
+None of this is structured. None of it is queryable by tooling. None of it round-trips
+through the IR. Migration tools that parse SecLang lose every comment except the immediate
+pre-rule comment, and even that is opaque text.
+
+### What this proposal must address
+
+- **Per-rule narrative** — what the rule detects, why, references (CWE, OWASP, CVE),
+  known false positives, related rules
+- **Per-group narrative** — replaces the file-level banner comment. Groups (ADR-0006,
+  ADR-0011) are now the cohesion unit, not files. A `group "sql_injection"` deserves the
+  same kind of overview that `REQUEST-942-APPLICATION-ATTACK-SQLI.conf` has today.
+- **Per-ruleset narrative** — what the distribution is, version policy, supported
+  targets, paranoia model, scoring model. Today scattered across README/CHANGES/setup-conf
+  comments.
+- **Cross-cutting attribute documentation** — paranoia levels, severity levels, scoring
+  categories: shared concepts that don't belong inside any one group but need
+  authoritative documentation.
+- **Documentation on rule-management directives** — `exclude rule` and `update rule`
+  (ADR-0006) deserve a "why" comment, just as rules do.
+
+### What's out of scope
+
+- Documentation versioning beyond what's already tracked in git
+- Localized/translated documentation (English-only for this proposal)
+- Auto-generated documentation from rule structure (separate tooling concern)
+- The CRS website's full content model (the website consumes this ADR's output, but
+  its layout and styling are not the language's concern)
+
+## Decision
+
+CRSLang adopts a **layered documentation model** with two complementary mechanisms:
+
+1. **Doc-comments** (Rust/Go style) — `///` comment lines that attach to the next AST
+   node. Used for narrative prose: descriptions, rationale, examples, FP notes.
+2. **Structured documentation fields** — typed metadata for machine-readable content:
+   `references`, `cwe`, `owasp`, `false_positives`, `see_also`. Used by tooling
+   (crs-toolchain, IDE hovers, audit log enrichment, `--explain` mode).
+
+Documentation attaches at four tiers: **ruleset → group (nestable) → rule → directive**.
+
+### Tier 1: Ruleset
+
+The top-of-file narrative, replacing scattered README/CHANGES/comment content.
+
+```
+/// OWASP Core Rule Set — generic attack detection for web applications.
+///
+/// This ruleset covers OWASP Top 10 attack categories using anomaly scoring with
+/// paranoia gating. Default deployment uses paranoia level 1; higher levels
+/// trade false-positive rate for broader detection.
+///
+/// References:
+///   - https://coreruleset.org/
+///   - OWASP Top 10:2021
+ruleset "OWASP_CRS" version "4.18.0" {
+  description {
+    paranoia_model = "1-4, see paranoia { } block below"
+    scoring_model  = "anomaly accumulation, threshold in config { scoring {} }"
+    targets        = ["seclang", "coraza"]
+  }
+}
+```
+
+The optional `description {}` block carries structured fields that don't fit naturally
+in a doc-comment. This block is open-ended — fields are documented in the CRSLang spec
+but adding new ones is a non-breaking change.
+
+### Tier 2: Group (nestable)
+
+Groups carry the file-level documentation that today lives in `.conf` banner comments.
+**Groups can nest** for conceptual sub-grouping, but nesting is reserved for genuine
+hierarchical cohesion — not for crossing orthogonal axes (paranoia, severity, phase).
+
+```
+/// SQL Injection detection.
+///
+/// Covers SQLi via libinjection (detectSQLi operator) and pattern-based detection
+/// across query string, POST body, headers, and cookies. PL1 covers high-confidence
+/// patterns; PL2-4 progressively widen detection at the cost of FP rate.
+///
+/// Common false-positive families:
+///   - Admin UIs that legitimately accept SQL fragments
+///   - Search forms with SQL keywords in the query
+///   - JSON APIs that include SQL-like strings as data values
+group "sql_injection" {
+  category = "sqli"
+
+  references     = ["CWE-89", "OWASP A1:2021"]
+  false_positives = [
+    "Admin UIs accepting SQL fragments — apply targeted exclusions",
+    "Search forms with SQL keywords — exclude on the search field",
+  ]
+
+  /// libinjection-based detection. Uses detectSQLi() on URL-decoded args.
+  group "libinjection_based" {
+    rule 942100 (paranoia: 1, severity: critical) { ... }
+    rule 942110 (paranoia: 2, severity: critical) { ... }
+  }
+
+  /// Pattern-based detection. Catches patterns libinjection misses (UNION-based,
+  /// time-based blind, comment injection).
+  group "pattern_based" {
+    rule 942120 (paranoia: 2) { ... }
+  }
+}
+```
+
+#### Nesting Semantics
+
+- Inner groups **inherit** outer group's structured fields (`category`, guards from
+  `requires:`, default action). Inner can add or override.
+- Doc-comments do **not** inherit — each group has its own narrative.
+- Guards **compose** via conjunction: outer `(requires: paranoia >= 1)` + inner
+  `(requires: paranoia >= 2)` = effective `paranoia >= 2`.
+- Nesting depth is unlimited but expected to stay shallow (1-2 levels in practice).
+
+### Tier 3: Rule
+
+Per-rule documentation with both narrative and structured fields:
+
+```
+/// SQL injection via libinjection on URL-decoded query string and POST args.
+///
+/// References:
+///   - CWE-89
+///   - https://github.com/libinjection/libinjection
+///
+/// Known false positives:
+///   - Search queries containing SQL keywords (use exclusion on the search field)
+rule 942100 (
+  severity:   critical,
+  paranoia:   1,
+  references: ["CWE-89"],
+) {
+  when request.args |> detect_sqli()
+  then block
+}
+```
+
+Doc-comments carry prose; the `references:` metadata field carries a machine-readable
+list. Tooling can render the prose, link the references, and emit both in audit logs.
+
+### Tier 4: Rule-Management Directives
+
+`exclude rule` and `update rule` (ADR-0006) carry their own documentation — an
+exclusion without an explanation is a maintenance hazard:
+
+```
+/// Admin UI legitimately accepts SQL fragments in the "query" field of the
+/// query builder at /admin/query-builder. Reviewed by security team 2026-04-12.
+exclude rule 942100 target request.args.post["query"]
+  where request.uri |> starts_with("/admin/query-builder")
+
+/// Bumped severity for our payment endpoints — SQLi here is an immediate
+/// PCI-DSS incident, not just a CRS event.
+update rule 942100 {
+  severity = critical_payment
+}
+```
+
+### Cross-Cutting Attribute Documentation
+
+Concepts like paranoia levels and severity levels span every group and rule. They get
+their own documentation construct, parallel to `globals { scoring {} }` from ADR-0011:
+
+```
+paranoia {
+  /// High-confidence detections. Minimal false positives expected. Default for
+  /// most deployments. Suitable for production traffic without exclusions.
+  level 1 {
+    expected_fp_rate = "<1%"
+    coverage         = "common attack patterns, well-known signatures"
+  }
+
+  /// Broader coverage. Some false positives expected; targeted exclusions
+  /// usually needed for application-specific traffic.
+  level 2 {
+    expected_fp_rate = "1-5%"
+    coverage         = "obfuscated variants, less-common attack patterns"
+  }
+
+  level 3 { ... }
+  level 4 { ... }
+}
+```
+
+This block is metadata-only — it does not affect rule evaluation. Tooling and the
+ruleset documentation generator consume it to explain what each paranoia level means
+for deployers.
+
+### IR Representation
+
+```go
+type Documentation struct {
+    DocComment string                  // narrative prose from /// comments
+    Fields     map[string]Value        // structured fields (references, cwe, etc.)
+}
+
+// Attached to each documentable AST node:
+type Ruleset   struct { Doc *Documentation; ... }
+type Group     struct { Doc *Documentation; Children []GroupChild; ... }
+type Rule      struct { Doc *Documentation; Metadata Metadata; ... }
+type Exclusion struct { Doc *Documentation; ... }
+type Update    struct { Doc *Documentation; ... }
+
+// Cross-cutting attribute docs (separate top-level blocks):
+type ParanoiaDocs struct { Levels map[int]*Documentation }
+type SeverityDocs struct { Levels map[Severity]*Documentation }
+```
+
+Doc-comments are stored as a single string (the `///` lines concatenated, leading marker
+stripped). Tooling that wants to parse internal structure (e.g., extract a "References:"
+section) does so over the prose; the language doesn't impose a sub-structure on the
+narrative.
+
+### Surface Syntax
+
+Doc-comments shown above use `///` as the marker. The exact marker depends on the
+Phase 0 language base decision (see ADR-0009):
+
+- **Custom parser:** `///` doc-comments that attach to the next AST node, plus
+  structured fields in the metadata clause. Native, lightweight.
+- **HCL:** HCL does not have node-attached doc-comments. The same content goes into
+  multi-line `description` and structured-field attributes:
+  ```hcl
+  rule "942100" {
+    severity = "critical"
+    description = <<-EOT
+      SQL injection via libinjection...
+    EOT
+    references = ["CWE-89"]
+  }
+  ```
+
+The IR is identical regardless of surface syntax. The compiler/parser populates the
+`Documentation` struct from whichever surface form it sees.
+
+### YAML Round-Trip
+
+YAML serialization captures the documentation natively:
+
+```yaml
+kind: rule
+metadata:
+  id: 942100
+  severity: critical
+  paranoia: 1
+documentation:
+  description: |
+    SQL injection via libinjection on URL-decoded query string and POST args.
+  references:
+    - CWE-89
+    - https://github.com/libinjection/libinjection
+  false_positives:
+    - "Search queries containing SQL keywords"
+when: ...
+then: ...
+```
+
+The `description` field carries the doc-comment prose (multi-line YAML string). All
+other structured fields carry through directly.
+
+### Compilation to SecLang
+
+SecLang's documentation model is limited to `msg:`, `tag:`, and `#` comments. The
+compiler maps the documentation IR back as follows:
+
+| CRSLang | SecLang output |
+|---|---|
+| Rule doc-comment first line | `msg:` |
+| Rule doc-comment full text | `#` comment block above the rule |
+| Group doc-comment | `#` banner above the group's compiled rules |
+| Ruleset doc-comment | `#` banner at the top of the generated file |
+| `references` field | `tag:cwe/89`, `tag:owasp/a1-2021`, etc. |
+| `false_positives` field | `#` comment block above the rule |
+| `paranoia { level N {} }` docs | dropped (no SecLang equivalent); preserved in YAML |
+
+Round-trip is **not lossless** in the SecLang direction — SecLang cannot represent
+nested groups or structured documentation. The CRSLang→SecLang export is deliberately
+treated as a downgrade. Authors edit CRSLang; SecLang is the deployment target.
+
+### Compilation to Other Targets
+
+For Cloud Armor, AWS WAF, and Cloudflare (ADR-0010), documentation maps to whatever
+labels, descriptions, or annotations the target supports. Most cloud WAFs accept a
+`description` field per rule; structured fields become tags or labels where supported,
+or are dropped where not. The compiler emits a target-specific manifest noting what
+was preserved vs dropped.
+
+### Tooling Contract
+
+Documentation is consumed by:
+
+- **crs-toolchain** — generates the CRS website from the IR's documentation nodes
+- **LSP / IDE** — hover, go-to-definition for rule references, autocomplete for tag values
+- **`--explain` CLI mode** — given a rule ID or matched event, prints the rule's
+  description, references, and FP notes
+- **Audit log enrichment** — embed rule description and references into audit log
+  entries for downstream SOC tooling
+- **Test report generation** — FP notes inform test case generation
+
+Each consumer reads from the same `Documentation` IR struct. Adding a new tooling
+consumer doesn't require schema changes.
+
+## Alternatives Considered
+
+### A: Inline metadata extension only
+
+Push everything into the existing `metadata = "(" metadata_kv ")"` clause with multi-line
+string support.
+
+**Rejected because:**
+- Rules with substantial documentation become unreadable inline
+- Forces the metadata clause to handle multi-paragraph prose, which fights its parens-
+  delimited design
+- No good way to distinguish narrative from machine-readable fields
+
+### B: Sidecar markdown files only
+
+Keep rule definitions lean; put all documentation in `rules/942100.md` files linked by
+filename or rule ID.
+
+**Rejected because:**
+- Drift risk: a rule's logic changes without its docs being updated
+- No IR-level documentation for tooling — the `--explain` mode would have to load and
+  parse markdown separately
+- Two-file workflow is friction for authors editing both
+- Loses the natural co-location that doc-comments provide
+
+(Note: external markdown is still useful for *very* long-form content like the
+paranoia model deep-dive. The CRS website can pull narrative from CRSLang docs and
+augment it with sidecar markdown for content that doesn't fit per-rule.)
+
+### C: Dedicated `doc {}` block inside each rule
+
+```
+rule 942100 (severity: critical) {
+  doc {
+    description = "..."
+    references  = [...]
+  }
+  when ...
+  then ...
+}
+```
+
+**Considered viable but:**
+- More vertical noise on every rule (every rule gets a `doc { }` even for short docs)
+- Description still wants multi-line strings, which works but feels heavier than `///`
+- Doc-comments are a more familiar pattern from Rust, Go, TypeScript, Python (`"""..."""`)
+
+The structured fields still appear (references, false_positives) but as top-level
+metadata or alongside metadata, not inside a separate `doc {}` block.
+
+### D: Comments as data (parse SecLang `#` comments and surface them)
+
+Treat existing `#` comments as the documentation source; no new constructs.
+
+**Rejected because:**
+- Loses structure entirely — everything is opaque text
+- Tooling can't reliably extract references, FP notes, etc.
+- SecLang comments are the *current* state and the problem this ADR solves
+
+### E: Tags as the only structured documentation
+
+Reuse the existing `tags:` array for everything: `tag:cwe/89`, `tag:fp/admin-ui`, etc.
+
+**Rejected because:**
+- Tags are flat strings; nested or multi-field structures don't fit
+- Tag namespace pollution — mixing taxonomic tags with documentation tags makes both
+  harder to query
+- No room for prose narrative
+
+## Consequences
+
+### Positive
+
+- Per-rule documentation gains a structured home with both narrative (doc-comments)
+  and machine-readable (`references`, `false_positives`) channels
+- Group-level documentation replaces opaque file headers with structured, queryable content
+- Ruleset-level documentation centralizes information today scattered across
+  README/CHANGES/setup-conf comments
+- Cross-cutting concepts (paranoia, severity) get authoritative documentation that
+  doesn't have to live inside any one group
+- Tooling has a single, consistent IR contract — `crs-toolchain`, IDE LSP, audit log
+  enrichment, and `--explain` all read from the same `Documentation` nodes
+- Exclusions and updates carry "why" comments, reducing drift in custom deployments
+- YAML serialization preserves everything; SecLang export degrades gracefully
+
+### Negative
+
+- More to write per rule. Authors who don't fill in docs leave the rule silent in
+  tooling. Mitigated by: doc-comments are optional, lint can warn on missing docs for
+  rules above a severity threshold.
+- Two mechanisms (doc-comments + structured fields) means authors must understand the
+  split — narrative vs machine-readable. Mitigated by: a clear style guide.
+- Group nesting adds grammar surface. Mitigated by: nesting is optional, most groups
+  stay flat, and the inheritance rules are simple.
+
+### Risks
+
+- **Convention drift** — without enforcement, doc-comments may become stale. The CRS
+  test pipeline can include doc-coverage checks (e.g., every rule above severity
+  warning must have a description).
+- **Cross-target degradation** — SecLang and cloud WAFs preserve only a subset of
+  documentation. Authors editing in CRSLang must understand that exporting to SecLang
+  loses nested group docs and structured fields beyond `tag:`. The migration tooling
+  should print a clear summary of what was preserved.
+- **HCL surface complexity** — if HCL is chosen as the language base, doc-comments
+  become structured `description` attributes, which is verbose for small docs. The
+  trade-off is part of the Phase 0 language base decision (ADR-0009).
+- **Schema growth** — structured fields (`references`, `false_positives`, `cwe`,
+  `owasp`, etc.) will accumulate over time. The IR's `Fields map[string]Value` keeps
+  this open-ended; the spec documents which fields are recognized by core tooling.

--- a/docs/adr/0014-imports-and-modularity.md
+++ b/docs/adr/0014-imports-and-modularity.md
@@ -1,0 +1,316 @@
+# ADR-0014: Imports and Modularity
+
+- **Status:** Proposed
+- **Date:** 2026-04-25
+- **Phase:** 4 (text syntax era; affects how multi-file rulesets compose)
+
+## Context
+
+CRS today is a directory of SecLang `.conf` files loaded by the engine via implicit
+filesystem ordering and `Include` directives:
+
+```
+modsecurity.conf
+├── Include /etc/modsec/crs-setup.conf
+├── Include /etc/modsec/rules/REQUEST-901-INITIALIZATION.conf
+├── Include /etc/modsec/rules/REQUEST-905-COMMON-EXCEPTIONS.conf
+├── Include /etc/modsec/rules/REQUEST-911-METHOD-ENFORCEMENT.conf
+└── ...
+```
+
+Several proposals reference this multi-file structure without formalizing it:
+- ADR-0012 mentions `setup.crs`, `main.crs`, `rules/REQUEST-920-...crs`
+- ADR-0013 documents groups as the cohesion unit, replacing per-file banners
+- ADR-0006 references rules across files via ID for `exclude rule` and `update rule`
+
+But the proposals do not specify:
+- How a file imports another
+- Whether load order matters semantically
+- How rule IDs / group names / macros are namespaced
+- What happens on conflict (duplicate rule IDs across files)
+- How a deployer overrides an upstream group from a separately-distributed package
+- How a downstream "custom rules" file extends the upstream CRS distribution
+
+Without an explicit modularity model, every multi-file feature in the other ADRs is
+under-specified.
+
+### What multi-file rulesets need
+
+1. **Explicit composition** — a deployer's `main.crs` lists what it imports, in what
+   order. No filesystem-glob magic, no hidden ordering.
+2. **Single global namespace for rule IDs** — rule 942100 means the same thing
+   everywhere; uniqueness is enforced at compile time across all imported files.
+3. **Hierarchical namespacing for groups, macros, and data** — `crs.sql_injection` is
+   distinct from `myorg.custom_sqli`; downstream consumers don't accidentally collide
+   with upstream package contents.
+4. **Path resolution that's predictable** — relative to the importing file, with a
+   defined search path for distributed packages.
+5. **Override mechanism that's explicit** — a downstream file can modify upstream rules
+   only via the rule-management directives (ADR-0006); silent shadowing is not allowed.
+6. **Idempotent imports** — importing the same file twice produces one effect, not two.
+
+## Decision
+
+CRSLang adopts an **explicit `import` directive** with **hierarchical namespaces** for
+groups, macros, and external data, and a **single flat namespace** for rule IDs.
+
+### Import Syntax
+
+```
+import "path/to/file.crs"
+import "path/to/file.crs" as alias
+import package "owasp_crs/4.18"
+```
+
+Three forms:
+
+1. **Path import** — loads the named file relative to the current file's directory.
+2. **Aliased import** — loads the file and binds its top-level namespace to a local alias.
+   Group references inside the importing file can then use the alias as a prefix.
+3. **Package import** — loads a named package from the configured search path. Used for
+   distributed rulesets (CRS itself, third-party rule packs).
+
+### Path Resolution
+
+Path imports resolve relative to the importing file's directory. No `..` traversal
+allowed past the ruleset root, defined as the directory containing the entry-point
+file (typically `main.crs`).
+
+Package imports resolve via a search path defined in `config {}` (ADR-0012):
+
+```
+config {
+  package_path = [
+    "./vendor",
+    "/usr/share/crslang/packages",
+  ]
+}
+```
+
+The first matching path wins. Package versions are encoded in the package name
+(`owasp_crs/4.18`), not as a separate field — packages are distributed as versioned
+directory trees.
+
+### Namespaces
+
+**Rule IDs are flat and global.** Every rule across every imported file shares a single
+ID space. Duplicate IDs are a compile-time error. This matches SecLang behavior and
+preserves the property that `exclude rule 942100` is unambiguous across the entire
+ruleset.
+
+**Groups, macros, and external data are namespaced** by the file or package they're
+declared in. The fully-qualified name uses dot notation:
+
+```
+# in owasp_crs/rules/sql_injection.crs
+group "sql_injection" {
+  macro detect() = request.args |> detect_sqli()
+  rule 942100 { ... }
+}
+
+# in deployer's main.crs
+import package "owasp_crs/4.18" as crs
+
+# crs.sql_injection refers to the imported group
+exclude group crs.sql_injection target request.args.post["query"]
+
+# crs.sql_injection.detect references the macro
+rule 999100 (severity: critical) {
+  when crs.sql_injection.detect()
+  then block
+}
+```
+
+Within a file, names resolve in this order: local declarations → aliased imports →
+unaliased imports (last-import-wins on collision, with a compile-time warning).
+
+### Load Order
+
+The order of `import` statements in a file determines load order. Compilation processes
+imports depth-first: each imported file is fully loaded (including its own imports)
+before the importing file's body is evaluated.
+
+For SecLang output, load order matters because rule evaluation order in SecLang follows
+file order. The compiler emits rules in the order they were declared (across imports),
+preserving the deployer's intent.
+
+For other targets (Cloud Armor, AWS WAF), order is preserved where the target supports
+it. Where the target evaluates rules in priority order rather than declaration order,
+the compiler maps declaration order to priority numbers.
+
+### Idempotency
+
+Importing the same file twice is a no-op on the second import. The compiler tracks
+imported files by canonical path; re-imports do not duplicate rules, groups, or macros.
+
+This means diamond-shape import graphs (A imports B and C; B and C both import D) work
+correctly: D is loaded once.
+
+### Conflict Resolution
+
+| Conflict | Resolution |
+|---|---|
+| Duplicate rule ID across imports | Compile-time error |
+| Duplicate group name in same namespace | Compile-time error |
+| Duplicate macro name in same namespace | Compile-time error |
+| Macro/group name collision in same namespace | Compile-time error |
+| Local name shadows imported name | Compile-time warning; local wins |
+| Two unaliased imports define the same name | Compile-time error |
+
+Conflicts are never silent. Authors must either rename, alias, or use the rule-management
+directives (ADR-0006) to express override intent explicitly.
+
+### Override Mechanism
+
+Downstream consumers do not modify upstream files. They modify upstream behavior via
+ADR-0006 directives:
+
+```
+# main.crs
+import package "owasp_crs/4.18" as crs
+
+# Disable a specific rule
+exclude rule 942100
+
+# Change a rule's severity
+update rule 942100 {
+  severity = critical_payment
+}
+
+# Disable an entire group
+exclude group crs.sql_injection where request.uri |> starts_with("/admin")
+
+# Add custom rules in a deployer-owned namespace
+group "myorg.custom_payment_protection" {
+  rule 9100100 (severity: critical) {
+    when request.uri |> starts_with("/payment")
+     and request.body |> contains("sql_keyword")
+    then block
+  }
+}
+```
+
+The `exclude` and `update` directives in `main.crs` reference imported names by
+fully-qualified path. The upstream package files are never modified.
+
+### Distribution Model
+
+A CRSLang package is a directory tree:
+
+```
+owasp_crs/4.18/
+├── package.crs              # entry point — declares the package
+├── setup.crs.example        # deployer-editable defaults
+├── rules/
+│   ├── sql_injection.crs
+│   ├── xss.crs
+│   └── ...
+└── tests/                   # FTW test cases (per ADR-0013)
+```
+
+`package.crs` declares the package and re-exports the rule files:
+
+```
+package "owasp_crs" version "4.18.0" {
+  description = "OWASP Core Rule Set"
+  targets     = ["seclang", "coraza"]
+}
+
+import "rules/sql_injection.crs"
+import "rules/xss.crs"
+# ... etc.
+```
+
+A deployer's `main.crs` imports the package:
+
+```
+import package "owasp_crs/4.18" as crs
+import "setup.crs"          # deployer-edited config
+
+# Optional deployer-specific rules
+import "custom/payment.crs"
+```
+
+### Compilation Output
+
+For SecLang export, all imports are flattened into the output `.conf` file with banner
+comments delineating the source:
+
+```
+# ===== imported from owasp_crs/4.18/rules/sql_injection.crs =====
+SecRule ARGS "@detectSQLi" \
+    "id:942100,..."
+# ===== end owasp_crs/4.18/rules/sql_injection.crs =====
+```
+
+For YAML export, the import structure is preserved as nested documents or a manifest
+file pointing to per-import YAML files (deployer's choice).
+
+## Alternatives Considered
+
+### A: Filesystem-glob discovery (current SecLang behavior)
+
+Load all `*.crs` files in a directory, alphabetically.
+
+**Rejected because:**
+- Order depends on filenames; renaming a file changes evaluation order silently
+- No way to express "use these files but not those"
+- Conflicts with package distribution (which file in which directory is "the" package?)
+- Hidden coupling: removing a file changes behavior elsewhere with no compile-time signal
+
+### B: Single-file rulesets only
+
+Require all rules in one file. No imports.
+
+**Rejected because:**
+- CRS today has ~50 files for good reason; 50,000-line files are unmaintainable
+- Loses the cohesion benefit of grouping by attack family
+- No package distribution model possible
+
+### C: Implicit namespacing by file path
+
+Every file's contents are automatically namespaced by its path; no explicit `as alias`.
+
+**Considered viable but:**
+- Long namespaces (`rules/protocol_enforcement/methods.crs.allowed_methods`) are awkward
+- Renaming a file silently changes references
+- Aliases give the deployer naming control without forcing path-based names
+
+### D: First-class merge directive
+
+`merge group crs.sql_injection { ... add more rules ... }` for downstream additions.
+
+**Rejected because:**
+- ADR-0006's `update` and `exclude` already cover modification
+- Adding new rules in a deployer namespace (`myorg.custom_*`) is cleaner than merging
+  into upstream namespaces
+- Merging blurs the "upstream/downstream" boundary; explicit namespaces preserve it
+
+## Consequences
+
+### Positive
+
+- Multi-file rulesets have a clear, predictable composition model
+- Package distribution becomes a first-class concept (CRS itself, third-party packs)
+- Conflicts are caught at compile time, never silent
+- Override semantics (ADR-0006) work cleanly across package boundaries
+- Diamond imports work correctly via idempotency
+- Deployer customizations live in a separate namespace from upstream content
+
+### Negative
+
+- Authors must write `import` statements explicitly (vs SecLang's implicit `Include`)
+- Namespace resolution rules (local → aliased → unaliased) require learning
+- Package distribution requires a directory layout convention; not just "put files anywhere"
+
+### Risks
+
+- **Migration friction** — existing CRS deployments use a flat directory of `.conf`
+  files with implicit ordering. The migration tool must generate a `main.crs` with
+  the right import order to preserve behavior. This is automatable but needs care.
+- **Package versioning conflicts** — if a deployer imports `owasp_crs/4.18` and a
+  third-party pack imports `owasp_crs/4.17`, there's a conflict. The compiler must
+  detect this and require the deployer to pin a single version.
+- **Deep import graphs** — large rulesets with many cross-imports may be hard to
+  reason about. Tooling (visualization, dependency analysis) helps; the language
+  itself doesn't restrict graph shape beyond enforcing acyclicity.

--- a/docs/adr/0014-imports-and-modularity.md
+++ b/docs/adr/0014-imports-and-modularity.md
@@ -122,7 +122,10 @@ rule 999100 (severity: critical) {
 ```
 
 Within a file, names resolve in this order: local declarations → aliased imports →
-unaliased imports (last-import-wins on collision, with a compile-time warning).
+unaliased imports. If two unaliased imports define the same name, that is a
+compile-time error. Warnings apply only when a higher-precedence name (for example,
+a local declaration or aliased import) shadows a name that would otherwise be
+available from an unaliased import.
 
 ### Load Order
 

--- a/docs/adr/0015-macros-and-compositions.md
+++ b/docs/adr/0015-macros-and-compositions.md
@@ -98,11 +98,14 @@ compile error.
 
 Macros live at three scope levels:
 
-1. **File scope** — declared at the top of a file, visible only within that file.
+1. **File scope** — declared at the top of a file. Visible directly within the
+   declaring file, and visible to other files in the same package only when those
+   files explicitly `import` the declaring file (per ADR-0014).
 2. **Group scope** — declared inside a group, visible only within that group and any
    nested groups.
-3. **Package scope** — exported by a package's `package.crs`, visible to importers
-   under the package's namespace (per ADR-0014).
+3. **Package scope** — declared with `export` (see [Exports](#exports) below), making
+   the macro visible to consumers that import the package as a whole, under the
+   package's namespace (per ADR-0014).
 
 ```
 # package.crs (CRS distribution)
@@ -166,8 +169,10 @@ use is determined by ADR-0014's namespacing rules:
 | Group scope inside nested groups `outer.inner` | `crs.outer.inner.<macro_name>` |
 
 `export` does not affect visibility *within* the package — a non-exported macro is
-still usable by other files in the same package per the normal scoping rules. The
-keyword only controls visibility *across* the package boundary.
+still usable by other files in the same package via an explicit `import` of the
+declaring file (per ADR-0014). The keyword only controls visibility *across* the
+package boundary, i.e., whether consumers that `import package "<name>"` can
+reference the macro under the package namespace.
 
 #### Default visibility rationale
 
@@ -276,6 +281,7 @@ The macro concept is the same in both language bases (Phase 0 / ADR-0009), but t
 surface differs:
 
 **Custom parser:**
+
 ```
 macro deep_normalize(input: string) = input
   |> utf8_to_unicode()
@@ -286,24 +292,29 @@ macro deep_normalize(input: string) = input
 **HCL:**
 
 HCL doesn't have first-class parameterized macros. Two options:
+
 - Use `locals` with no parameters (function-call equivalents):
+
   ```hcl
   locals {
     safe_methods_pattern = "^(?:GET|HEAD|OPTIONS)$"
   }
   ```
+
 - Add a custom `macro` block via HCL extension (the project already extends HCL with
   custom block types):
+
   ```hcl
   macro "deep_normalize" {
     param "input" { type = string }
     body  = "url_decode(html_entity_decode(remove_nulls(input)))"
   }
   ```
+
   HCL's `templatefile()` and `function()` extension mechanisms make this feasible.
 
 The IR is identical regardless of surface — both forms produce the same
-`MacroDeclaration` and `MacroCall` AST nodes.
+`MacroDecl` and `MacroCall` AST nodes.
 
 ### Macro vs Function Distinction
 

--- a/docs/adr/0015-macros-and-compositions.md
+++ b/docs/adr/0015-macros-and-compositions.md
@@ -1,0 +1,344 @@
+# ADR-0015: Macros and Named Compositions
+
+- **Status:** Proposed
+- **Date:** 2026-04-25
+- **Phase:** 3 (function composition era; partially shapes Phase 0 language base decision)
+
+## Context
+
+Multiple ADRs reference reusable function compositions ("named macros", "named function
+compositions") without specifying how they're defined or scoped:
+
+- ADR-0002 (pipeline operator): "reusable transform chains are defined once and invoked
+  by name"
+- ADR-0009 (language base evaluation): HCL vs custom decision partially hinges on
+  what macros look like — HCL doesn't have parameterized expression macros natively,
+  custom can have whatever shape the parser supports
+- README Phase 3: "named function compositions (macros) keep nesting shallow"
+- ADR-0014 (imports): macros are namespaced like groups and external data
+
+The actual macro design has never been written down.
+
+### What needs reuse
+
+CRS today has many transformation chains that repeat across rules:
+
+```
+t:none,t:utf8toUnicode,t:urlDecodeUni,t:htmlEntityDecode,t:jsDecode,t:cssDecode,t:removeNulls
+```
+
+This 7-step "deep normalization" chain appears in dozens of XSS and SQLi rules. Today
+it's copy-pasted with the risk of one rule getting it slightly wrong.
+
+CRS also has predicate-side reuse:
+- "is this method GET or HEAD?" → `request.method |> matches("^(?:GET|HEAD)$")`
+- "is this from a trusted IP?" → `client.ip |> ip_in_range(trusted_ips)`
+- "is this a static asset?" → `request.uri |> matches("\\.(?:css|js|png|gif)$")`
+
+These are repeated across many rules. They deserve names.
+
+### What macros are not
+
+- **Not functions**: macros do not introduce new operators or runtime behavior. They are
+  named compositions of existing functions.
+- **Not templates**: macros do not generate rules. A macro produces a value (an
+  expression result), not a rule.
+- **Not stateful**: macros cannot read or write TX state. They are pure expressions.
+
+## Decision
+
+CRSLang adopts **typed expression macros** — named, parameterized compositions of
+existing functions that produce a value when invoked. Macros are pure, side-effect-free,
+and resolved at compile time.
+
+### Definition Syntax
+
+```
+macro <name>([<param>: <type>, ...]) [: <return_type>] = <expression>
+```
+
+Examples:
+
+```
+# No parameters — a fixed pipeline applied to a fixed input field
+macro is_safe_method() = request.method |> matches("^(?:GET|HEAD|OPTIONS)$")
+
+# One parameter — applies a transformation chain to any input
+macro deep_normalize(input: string) = input
+  |> utf8_to_unicode()
+  |> url_decode_uni()
+  |> html_entity_decode()
+  |> js_decode()
+  |> css_decode()
+  |> remove_nulls()
+
+# Multi-parameter — predicate over two inputs
+macro request_from(field: string, allowlist: ip_list) =
+  field |> ip_in_range(allowlist)
+
+# Composition — macros calling macros
+macro is_xss_attempt(input: string) = input
+  |> deep_normalize()
+  |> detect_xss()
+```
+
+### Type Signatures
+
+Every macro has a typed signature, inferred or declared:
+
+- **Parameter types** — `string`, `int`, `bool`, `ip_list`, `regex_set`, `field_ref`,
+  field-namespace types from ADR-0001
+- **Return type** — usually inferred from the body. Can be declared for clarity:
+  `macro is_xss(...) : bool = ...`
+
+Type checking happens at compile time. A macro called with the wrong types is a
+compile error.
+
+### Scoping
+
+Macros live at three scope levels:
+
+1. **File scope** — declared at the top of a file, visible only within that file.
+2. **Group scope** — declared inside a group, visible only within that group and any
+   nested groups.
+3. **Package scope** — exported by a package's `package.crs`, visible to importers
+   under the package's namespace (per ADR-0014).
+
+```
+# package.crs (CRS distribution)
+package "owasp_crs" version "4.18.0"
+
+macro deep_normalize(input: string) = input
+  |> utf8_to_unicode()
+  |> url_decode_uni()
+  ...
+
+# rules/sql_injection.crs
+group "sql_injection" {
+  # Group-scoped macro (visible only inside this group)
+  macro args_are_sqli() = request.args |> detect_sqli()
+
+  rule 942100 (severity: critical) {
+    when args_are_sqli()           # local macro
+       or deep_normalize(request.body) |> contains("union")  # package macro
+    then block
+  }
+}
+
+# deployer's main.crs
+import package "owasp_crs/4.18" as crs
+
+rule 9100100 {
+  when crs.deep_normalize(request.headers["X-Custom"]) |> contains("attack")
+  then block
+}
+```
+
+Macros are not visible across imports unless explicitly exported. A package's
+`package.crs` lists which macros it exports.
+
+### Pure Expression Constraint
+
+Macro bodies are pure expressions. They cannot:
+
+- Read or write `tx.*`, `ip.*`, `global.*`, `session.*` (these are runtime state)
+- Have side-effects (logging, scoring, action invocation)
+- Reference rule attributes (severity, paranoia)
+- Contain `when`, `then`, or any rule-level keyword
+
+They can:
+
+- Reference any field from the typed namespace (ADR-0001)
+- Call any function in the standard library
+- Call other macros (acyclically — recursion is a compile error)
+- Use boolean operators (`and`, `or`, `not`) per ADR-0003
+- Use the pipeline operator (custom parser) or nested calls (HCL)
+
+This constraint keeps macros tractable: a macro call is always replaceable by its
+body. Tooling can inline macros without changing semantics.
+
+### No Recursion
+
+Macros cannot call themselves directly or indirectly. The compile-time call graph must
+be acyclic. This guarantees macro expansion terminates.
+
+### Compilation Strategy
+
+Macros are **inlined at compile time**. A macro call expands into its body with
+parameter substitution:
+
+```
+# Authored
+rule 942100 {
+  when args_are_sqli()
+  then block
+}
+
+# After inlining (intermediate form)
+rule 942100 {
+  when request.args |> detect_sqli()
+  then block
+}
+
+# Compiled SecLang (no trace of the macro)
+SecRule ARGS "@detectSQLi" "id:942100,phase:2,block,..."
+```
+
+The compiled output has no notion of "macro" — only the expanded expressions.
+
+### HCL vs Custom Surface
+
+The macro concept is the same in both language bases (Phase 0 / ADR-0009), but the
+surface differs:
+
+**Custom parser:**
+```
+macro deep_normalize(input: string) = input
+  |> utf8_to_unicode()
+  |> url_decode_uni()
+  |> remove_nulls()
+```
+
+**HCL:**
+
+HCL doesn't have first-class parameterized macros. Two options:
+- Use `locals` with no parameters (function-call equivalents):
+  ```hcl
+  locals {
+    safe_methods_pattern = "^(?:GET|HEAD|OPTIONS)$"
+  }
+  ```
+- Add a custom `macro` block via HCL extension (the project already extends HCL with
+  custom block types):
+  ```hcl
+  macro "deep_normalize" {
+    param "input" { type = string }
+    body  = "url_decode(html_entity_decode(remove_nulls(input)))"
+  }
+  ```
+  HCL's `templatefile()` and `function()` extension mechanisms make this feasible.
+
+The IR is identical regardless of surface — both forms produce the same
+`MacroDeclaration` and `MacroCall` AST nodes.
+
+### Macro vs Function Distinction
+
+| Aspect | Function | Macro |
+|---|---|---|
+| Defined by | Standard library or engine | Ruleset author |
+| Implementation | Native code (Go) | CRSLang expression |
+| Side effects | Possibly (rare) | None |
+| Compilation | Stays as a call | Inlined |
+| Examples | `matches()`, `count()`, `detect_sqli()` | `deep_normalize()`, `is_safe_method()` |
+
+Functions are the language's primitives; macros are user-defined named compositions
+of those primitives.
+
+### IR Representation
+
+```go
+type MacroDecl struct {
+    Doc        *Documentation        // from ADR-0013
+    Name       string                // local name within scope
+    Namespace  string                // package/file/group, per ADR-0014
+    Params     []MacroParam
+    ReturnType Type
+    Body       Expr                  // the typed AST of the expression
+}
+
+type MacroParam struct {
+    Name string
+    Type Type
+}
+
+type MacroCall struct {
+    Decl *MacroDecl
+    Args []Expr
+}
+```
+
+After macro inlining, `MacroCall` nodes are replaced by the substituted `Expr` from
+the macro's body. The decl is retained in the IR for tooling (cross-reference,
+documentation, refactoring).
+
+## Alternatives Considered
+
+### A: No macros — copy-paste pipelines
+
+Require every rule to spell out its full pipeline.
+
+**Rejected because:**
+- CRS already has the deep-normalize chain repeated across many rules; copy-paste
+  causes drift and inconsistency
+- Higher cognitive load when reading rules
+- Defeats one of the language's stated benefits (composability)
+
+### B: Macros as engine functions (no user-defined)
+
+Ship the standard library with `deep_normalize()` etc. baked in. Users cannot define
+their own.
+
+**Rejected because:**
+- Different deployers have different normalization needs (e.g., different sequences
+  for different content types)
+- Custom rule packs (third-party) want to ship their own conventions
+- Standard library would grow indefinitely to cover everyone's use cases
+
+### C: Macros with side effects (full procedures)
+
+Allow macros to log, set TX, etc.
+
+**Rejected because:**
+- Conflates expressions with statements
+- Compile-time inlining no longer trivially correct (ordering of side effects matters)
+- The action model (ADR-0004) already handles side effects in `then` blocks; macros
+  would duplicate or compete with that
+
+### D: Templating (rule-generating macros)
+
+`for severity in [critical, warning] { rule N { ... } }` style metaprogramming.
+
+**Rejected because:**
+- Generated rules are hard to understand and debug
+- Rule IDs become opaque (where did rule 942101 come from?)
+- The current model (group inheritance, severity attribute) covers the common cases
+
+### E: Recursive macros
+
+Allow self-referential macros for tree-walking patterns.
+
+**Rejected because:**
+- Compilation can fail to terminate without careful guards
+- No CRS use case currently requires recursion
+- Can be added later if a real need emerges
+
+## Consequences
+
+### Positive
+
+- Eliminates copy-paste of common pipelines (deep_normalize, safe_method check, etc.)
+- Type-checked at compile time — wrong-type arguments caught early
+- Macros + groups + imports + documentation form a coherent modularity story
+- Tooling can show macro expansion (e.g., IDE inlay hints, `--explain` mode)
+- Compiled output has no macro overhead — pure inlining
+
+### Negative
+
+- Authors learn a second naming layer (functions vs macros) and where each scope lives
+- Group-scoped macros mean the same name can resolve to different things in different
+  contexts; mitigated by IDE tooling and clear error messages
+- HCL surface for macros is awkward without language extension; pushes weight onto the
+  Phase 0 decision
+
+### Risks
+
+- **Macro proliferation** — without discipline, deployers may define macros for
+  trivial expressions, hurting readability. Style guide and lint rules can encourage
+  reuse only when a pipeline appears 3+ times.
+- **Type-checking complexity** — full type inference across macro calls requires the
+  type system from the second-tier "function signatures" gap. Until that's done,
+  type checking may be partial. Acceptable as long as runtime errors remain rare.
+- **Cross-target divergence** — non-SecLang targets may not support the same function
+  set; macros that compile cleanly to SecLang may fail to compile to Cloud Armor.
+  The multi-target compiler (ADR-0010) must report which macros are unsupported per
+  target.

--- a/docs/adr/0015-macros-and-compositions.md
+++ b/docs/adr/0015-macros-and-compositions.md
@@ -108,15 +108,19 @@ Macros live at three scope levels:
 # package.crs (CRS distribution)
 package "owasp_crs" version "4.18.0"
 
-macro deep_normalize(input: string) = input
+# Exported — visible to importers as crs.deep_normalize
+export macro deep_normalize(input: string) = input
   |> utf8_to_unicode()
   |> url_decode_uni()
   ...
 
 # rules/sql_injection.crs
 group "sql_injection" {
-  # Group-scoped macro (visible only inside this group)
+  # Group-scoped macro (visible only inside this group, not to importers)
   macro args_are_sqli() = request.args |> detect_sqli()
+
+  # Exported group-scope macro — visible to importers as crs.sql_injection.detect
+  export macro detect() = request.args |> detect_sqli()
 
   rule 942100 (severity: critical) {
     when args_are_sqli()           # local macro
@@ -134,8 +138,88 @@ rule 9100100 {
 }
 ```
 
-Macros are not visible across imports unless explicitly exported. A package's
-`package.crs` lists which macros it exports.
+The `export` keyword controls cross-package visibility — see [Exports](#exports) below.
+
+### Exports
+
+Macros default to **private**: visible only within their declaring scope. To make a
+macro visible to importers, prefix the declaration with the `export` keyword:
+
+```
+# rules/_common.crs (inside the OWASP_CRS package)
+export macro deep_normalize(input: string) = input
+  |> utf8_to_unicode()
+  |> url_decode_uni()
+  |> remove_nulls()
+
+# Not exported — file-scope helper, invisible outside _common.crs
+macro _strip_quotes(input: string) = input |> replace("\"", "")
+```
+
+`export` is allowed at file scope and at group scope. The qualified path importers
+use is determined by ADR-0014's namespacing rules:
+
+| Declaration site | Importer-visible name (with alias `crs`) |
+|---|---|
+| File scope, anywhere in the package | `crs.<macro_name>` |
+| Group scope inside a group named `bar` | `crs.bar.<macro_name>` |
+| Group scope inside nested groups `outer.inner` | `crs.outer.inner.<macro_name>` |
+
+`export` does not affect visibility *within* the package — a non-exported macro is
+still usable by other files in the same package per the normal scoping rules. The
+keyword only controls visibility *across* the package boundary.
+
+#### Default visibility rationale
+
+CRSLang chooses **explicit opt-in for exports** rather than opt-out (e.g., "every
+top-level macro is automatically exported"). Adding a new macro inside a package does
+not accidentally widen the public API surface. The `export` keyword is grep-able,
+making the package's external API enumerable with `rg '^export macro'`. This matches
+the convention in Rust (`pub`), TypeScript (`export`), and Python (`__all__`).
+
+#### Re-export from package.crs
+
+A package author who wants to expose macros that live in other files declares
+re-exports in `package.crs`:
+
+```
+# package.crs
+package "owasp_crs" version "4.18.0"
+
+import "rules/_common.crs"
+import "rules/sql_injection.crs"
+
+# Re-export individual names from imported files
+export macro deep_normalize from "rules/_common.crs"
+export macro is_safe_method from "rules/_common.crs"
+```
+
+Re-exports do not redefine the macro; they make an already-defined macro from another
+file visible to importers under the package namespace. This is needed only when the
+file authoring style keeps macros private at the file level but the package wants to
+expose them; if the macro is declared with `export macro` directly in its file, no
+re-export is needed.
+
+#### Conflict with ADR-0014's name resolution
+
+Re-exports go through the same conflict-resolution rules as ordinary declarations
+(ADR-0014). Two `export` declarations producing the same fully-qualified name across
+files of the same package are a compile-time error.
+
+#### HCL surface
+
+In the HCL surface (per ADR-0009), the equivalent is a `visibility` attribute on the
+macro block:
+
+```hcl
+macro "deep_normalize" {
+  visibility = "public"
+  param "input" { type = string }
+  body  = "..."
+}
+```
+
+The IR is identical: both surfaces produce a `MacroDecl` with `Exported = true`.
 
 ### Pure Expression Constraint
 
@@ -241,6 +325,7 @@ type MacroDecl struct {
     Doc        *Documentation        // from ADR-0013
     Name       string                // local name within scope
     Namespace  string                // package/file/group, per ADR-0014
+    Exported   bool                  // visible to importers (set by `export` keyword)
     Params     []MacroParam
     ReturnType Type
     Body       Expr                  // the typed AST of the expression

--- a/docs/adr/0016-external-data-sources.md
+++ b/docs/adr/0016-external-data-sources.md
@@ -1,0 +1,342 @@
+# ADR-0016: External Data Sources
+
+- **Status:** Proposed
+- **Date:** 2026-04-25
+- **Phase:** 3 (function composition era; data sources are referenced from pipelines)
+
+## Context
+
+CRS rules depend heavily on external data — lists, sets, databases — that the rule
+references but does not contain inline:
+
+- **IP allow/blocklists** — `tx.high_risk_country_codes`, customer-specific blocklists,
+  threat intel feeds
+- **Geo databases** — MaxMind GeoLite2 country/city/ASN lookups
+- **Regex assemblies** — CRS's `regex-assembly` files compile multi-pattern regexes from
+  structured `.ra` files
+- **String sets** — allowed methods, allowed content types, restricted extensions
+  (currently flattened into space-separated TX variables)
+- **Key-value maps** — sometimes used for header→action mappings
+- **Pre-computed indices** — pattern-matching tables for `@pm`-style multi-pattern
+  matching
+
+In SecLang, these are accessed via specialized operators:
+- `@ipMatchFromFile /path/to/ips.txt`
+- `@geoLookup` (uses `SecGeoLookupDb` from ADR-0008's engine config)
+- `@pmFromFile /path/to/patterns.txt`
+- `@rxFromFile /path/to/regex.txt`
+
+CRSLang has no story for any of this. Rules in current ADRs implicitly assume data is
+available (`client.ip in blocked_ips`, `request.uri |> matches_any(restricted_paths)`)
+without specifying where `blocked_ips` or `restricted_paths` come from.
+
+### What external data needs
+
+1. **Declaration** — a typed reference to an external file with a known format
+2. **Compile-time validation** — confirm the file exists and parses as the declared type
+3. **Predictable lookup** — same syntax for "is X in this set?" regardless of whether
+   the set is inline or external
+4. **Hot reload semantics** — some data (threat intel) updates frequently; the language
+   should express whether a data source is static or hot-reloadable
+5. **Multi-target compilation** — SecLang has `@ipMatchFromFile`; cloud WAFs have their
+   own list constructs (Cloud Armor's IP lists, AWS WAF IP sets); the compiler must
+   map appropriately
+
+## Decision
+
+CRSLang adopts a **typed `data` declaration** that names an external source with a
+declared type and format. Data sources are referenced from rules and macros as
+typed values, with operations dispatched based on the data type.
+
+### Declaration Syntax
+
+```
+data <name> from <source> type <type> [format <format>] [reload <policy>]
+```
+
+Examples:
+
+```
+# IP list from a file, hot-reloadable
+data blocked_ips
+  from "data/blocked_ips.txt"
+  type ip_list
+  format line_separated
+  reload on_change
+
+# Regex set from a CRS regex-assembly file
+data sqli_patterns
+  from "data/sqli.ra"
+  type regex_set
+  format regex_assembly
+
+# Country code allowlist (inline)
+data allowed_countries
+  type string_set
+  values ["US", "CA", "GB", "DE", "FR"]
+
+# Geo database (managed by engine, declared for reference)
+data geo_db
+  from "data/GeoLite2-Country.mmdb"
+  type geo_db
+  format mmdb
+  managed_by_engine
+
+# Multi-pattern matching set (compiled from individual patterns)
+data malware_signatures
+  from "data/malware.txt"
+  type string_set
+  format line_separated
+  reload static
+```
+
+### Data Types
+
+| Type | Lookup operations | Example file format |
+|---|---|---|
+| `ip_list` | `in`, `not_in`, `contains_ip()` | `192.168.0.0/16\n10.0.0.0/8\n...` |
+| `string_set` | `in`, `not_in`, `contains()` | `application/json\ntext/xml\n...` |
+| `regex_set` | `matches_any()`, `matches_assembly()` | `.ra` file or `pattern\n...` |
+| `kv_map` | `lookup(key)`, `has_key(key)` | `key=value\n...` (or JSON) |
+| `geo_db` | `geo_country(ip)`, `geo_asn(ip)`, `geo_city(ip)` | MaxMind `.mmdb` |
+| `pattern_table` | `pattern_match()` (Aho-Corasick) | `pattern\n...` |
+
+The standard library's matching functions are typed: `matches_any` accepts a `regex_set`
+and a `string`, `contains_ip` accepts an `ip_list` and an `ip`. Wrong-type arguments
+are compile errors.
+
+### Source Forms
+
+Three source forms:
+
+1. **`from "path"`** — load from a file. Path resolves relative to the declaring file
+   (per ADR-0014's path resolution rules).
+2. **`values [...]`** — inline literal values; no file involved. Useful for short
+   allowlists.
+3. **`from <url>`** — load from a URL (HTTPS only, with checksum verification). Used
+   for shared threat-intel feeds. Engine-dependent: not all targets support this.
+
+### Format Hints
+
+The `format` keyword tells the compiler how to parse the source. Defaults are inferred
+from the file extension when possible:
+
+| Format | Description |
+|---|---|
+| `line_separated` | One value per line, `#` comments and blanks ignored |
+| `csv` | Comma-separated; columns described by `columns: [...]` |
+| `json` | JSON array or object |
+| `regex_assembly` | CRS `.ra` format (compiled to a single regex) |
+| `mmdb` | MaxMind binary database |
+| `yaml` | YAML structure |
+
+Custom formats can be registered by ruleset authors via a parser plugin (out of scope
+for this ADR; deferred to a future "extension points" ADR).
+
+### Reload Policies
+
+- `static` (default) — loaded once at compile time. Becomes part of the compiled output.
+  Most performant; suitable for slow-changing data (allowed methods, file extensions).
+- `on_startup` — loaded once at engine startup. Suitable for medium-volatility data
+  (geo databases) that should not require recompilation.
+- `on_change` — engine watches the file and reloads on change. Suitable for high-
+  volatility data (threat intel feeds).
+- `interval: <duration>` — engine reloads on a fixed schedule.
+
+Not all targets support all reload policies. SecLang/Coraza supports static and
+on_startup. Cloud WAFs typically require on_startup or external propagation. The
+compiler reports which policies are supported per target.
+
+### Lookup Syntax
+
+External data is referenced as a value in expressions:
+
+```
+data blocked_ips from "data/ips.txt" type ip_list
+
+rule 902100 (severity: warning) {
+  when client.ip in blocked_ips
+  then block
+}
+```
+
+Or via typed operators:
+
+```
+data restricted_extensions from "data/restricted.txt" type string_set
+
+rule 920360 (severity: warning) {
+  when request.uri.basename |> ends_with_any(restricted_extensions)
+  then block
+}
+```
+
+For multi-pattern data:
+
+```
+data sqli_patterns from "data/sqli.ra" type regex_set format regex_assembly
+
+rule 942100 (severity: critical) {
+  when request.args |> matches_any(sqli_patterns)
+  then block
+}
+```
+
+### Compile-Time Validation
+
+For each `data` declaration, the compiler:
+
+1. Resolves the source path (or fetches the URL with checksum check)
+2. Parses the file according to the declared format
+3. Validates that contents match the declared type (e.g., `ip_list` must contain valid
+   IPs/CIDRs; `regex_set` must contain syntactically valid regexes)
+4. For static data, embeds the parsed contents in the compiled output
+5. For dynamic data, embeds a reference (path + checksum) and the engine loads at runtime
+
+Parse errors fail the compilation with file:line context.
+
+### Compilation to SecLang
+
+| CRSLang | SecLang output |
+|---|---|
+| `client.ip in <ip_list>` | `@ipMatchFromFile path` (file emitted alongside `.conf`) |
+| `field \|> matches_any(<regex_set>)` | `@rxFromFile path` |
+| `field \|> in_set(<string_set>)` | `@pmFromFile path` |
+| `geo_country(client.ip)` | `@geoLookup` + reference to `GEO:COUNTRY_CODE` |
+| Inline `values [...]` (small) | Expanded to a regex literal |
+| Inline `values [...]` (large) | Emitted as a generated file |
+
+Static data with small inline values may compile to inline regex/pattern literals for
+performance; the compiler picks based on size thresholds.
+
+### Compilation to Other Targets
+
+For Cloud Armor, AWS WAF, Cloudflare, and other cloud WAFs:
+
+- **Cloud Armor**: IP lists become Address Groups; string/regex sets become custom
+  rules with combined patterns; managed lists (GeoLite, threat intel) map to Cloud
+  Armor's preconfigured WAF rules where available.
+- **AWS WAF**: IP lists map to IPSets; regex sets map to RegexPatternSets; string
+  sets map to rule logic.
+- **Cloudflare**: IP lists map to IP Lists; regex sets compile inline (Wirefilter has
+  no separate list type).
+
+For each target, the compiler emits a separate manifest file describing what data
+sources to upload/configure outside the rule logic itself. ADR-0010's multi-target
+model handles the manifest format.
+
+### Engine-Managed vs Compiled-In
+
+Some data sources are managed by the engine, not the compiler:
+
+- `geo_db` is configured at the engine level (MaxMind path is engine config per ADR-0008)
+- Hot-reloadable data is loaded by the engine, not embedded by the compiler
+- The compiler emits references; the engine resolves them at runtime
+
+For these, `data` declarations are essentially type-checked references that document
+what the engine must provide. The compiler verifies the file exists at compile time
+but does not embed it.
+
+### IR Representation
+
+```go
+type DataDecl struct {
+    Doc       *Documentation        // ADR-0013
+    Name      string
+    Namespace string                // per ADR-0014
+    Type      DataType
+    Source    DataSource            // file, url, or inline
+    Format    DataFormat
+    Reload    ReloadPolicy
+    Static    bool                  // true if compiled-in
+}
+
+type DataType interface { /* ip_list, string_set, regex_set, etc. */ }
+
+type DataSource interface { /* FileSource, URLSource, InlineSource */ }
+```
+
+A `DataDecl` is referenced by name in the AST; the type system uses the declared
+`DataType` to validate operations applied to it.
+
+## Alternatives Considered
+
+### A: Inline-only data (no external files)
+
+Require all data to be inlined in the ruleset.
+
+**Rejected because:**
+- CRS regex assemblies and IP lists routinely have thousands of entries; inlining
+  becomes unmaintainable
+- Threat intel feeds must update faster than ruleset deployments
+- Geo databases are gigabytes; cannot be inlined
+
+### B: Untyped data references (string-based, like SecLang)
+
+Reference files by string path with no type:
+
+```
+when client.ip ipMatchFromFile "data/ips.txt" then block
+```
+
+**Rejected because:**
+- Loses compile-time validation (typos in paths, wrong file format)
+- Loses type-checking on operations (passing a regex file to an IP operator)
+- Discards the language's "typed everything" property
+
+### C: Data as fields in the namespace
+
+Treat external data as virtual fields under `data.*`:
+
+```
+when client.ip in data.blocked_ips
+```
+
+**Considered viable but:**
+- Conflates the field namespace (request data, response data, TX state) with reference
+  data (pre-loaded sets and lookups)
+- ADR-0001's namespace is for runtime-changing data; data sources are static or
+  engine-managed
+- Cleaner to have a separate `data` declaration and reference
+
+### D: Auto-discovery of data files
+
+Look for `*.txt`, `*.ra`, `*.mmdb` files in conventional directories and auto-import.
+
+**Rejected because:**
+- Same problems as ADR-0014's rejected filesystem-glob discovery: silent ordering,
+  brittle file naming, no compile-time signal when a file is missing
+- Type cannot be inferred from filename reliably
+
+## Consequences
+
+### Positive
+
+- IP lists, regex sets, string sets, and geo databases become first-class concepts
+- Compile-time validation of file existence, format, and type
+- Hot-reload semantics are explicit, not engine-implementation-dependent
+- Multi-target compilation has a clear model for what each target supports
+- Lookup syntax is uniform: same `in`, `matches_any`, etc. regardless of source
+- The CRS regex-assembly subsystem becomes integrated into the language
+
+### Negative
+
+- Authors must declare data sources explicitly (vs SecLang's "just point to a file")
+- Data type catalog must be extensible; standard library grows
+- Format support requires parsers in the compiler (line-separated, regex_assembly,
+  mmdb, JSON, YAML)
+
+### Risks
+
+- **Format proliferation** — every team has a slightly different data format. The
+  language must support extension (custom format parsers) without becoming a parser
+  zoo. Deferred extension-points ADR will address this.
+- **Hot-reload semantics across targets** — `reload on_change` works for Coraza
+  (file watch) but not Cloud Armor (requires API push). Compiler reports unsupported
+  policies per target; deployer handles target-specific provisioning.
+- **Source authenticity** — pulling data from URLs requires checksum verification
+  to prevent supply-chain attacks. The language enforces checksum declaration for
+  URL sources; without it, the compile fails.
+- **Large static data** — a 10MB IP list compiled into a SecLang `@ipMatchFromFile`
+  is fine, but if the compiler tries to inline it as a regex literal, performance
+  craters. Size thresholds for inline-vs-file decisions are needed.

--- a/docs/adr/0016-external-data-sources.md
+++ b/docs/adr/0016-external-data-sources.md
@@ -51,8 +51,25 @@ typed values, with operations dispatched based on the data type.
 ### Declaration Syntax
 
 ```
-data <name> from <source> type <type> [format <format>] [reload <policy>]
+data <name>
+  (from <source> | values [...])
+  [checksum  <"sha256:hex">]
+  [signed_by <"key-file">]
+  type <type>
+  [format <format>]
+  [reload <policy>]
+  [managed_by_engine]
 ```
+
+URL sources require at least one of `checksum` or `signed_by` (both may be present).
+File and inline sources accept `checksum` as an optional integrity check; `signed_by`
+is meaningful only for URL sources.
+
+The `managed_by_engine` clause marks the data as provided and lifecycle-managed by
+the engine (see [Engine-Managed vs Compiled-In](#engine-managed-vs-compiled-in)).
+When present, the compiler validates the declaration but does not embed or fetch
+the data; the engine resolves it at runtime. `managed_by_engine` is mutually
+exclusive with `reload` (the engine owns the reload policy).
 
 Examples:
 
@@ -113,11 +130,50 @@ Three source forms:
    (per ADR-0014's path resolution rules).
 2. **`values [...]`** — inline literal values; no file involved. Useful for short
    allowlists.
-3. **`from <url>`** — load from a URL (HTTPS only). URL sources **must** declare a
-   checksum using a sibling `checksum` field whose value is `sha256:<hex>`.
-   Example:
+3. **`from <url>`** — load from a URL (HTTPS only). URL sources require integrity
+   verification via one of two mechanisms (or both):
 
-   
+   - **`checksum "sha256:<hex>"`** — pin the payload to a specific content hash.
+     Suitable for *content-pinned* URLs where the bytes at the URL never change
+     (e.g., versioned releases like `crs-rules/4.18.0/sqli.ra`). Compatible with
+     `reload static` and `reload on_startup`. **Not** compatible with `reload
+     interval` or `reload on_change`, because a live-updating feed will fail
+     verification on the first reload — the checksum pins specific bytes, and
+     updates necessarily change those bytes.
+
+   - **`signed_by "<key-file>"`** — verify each fetch against a detached signature
+     served alongside the payload (conventionally at `<url>.sig`). The key file is a
+     path within the package (vendored as part of the deployment). Suitable for
+     live feeds because the signer is pinned, not the content — each new payload
+     can carry a fresh signature.
+
+   At least one of `checksum` or `signed_by` is required for URL sources. Both may
+   be declared together (the compiler verifies both).
+
+   ```
+   # Pinned: a versioned release URL where bytes never change at this path
+   data sqli_assembly
+     from     "https://example.com/crs-rules/4.18.0/sqli.ra"
+     checksum "sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+     type     regex_set
+     format   regex_assembly
+     reload   on_startup
+
+   # Live feed: signer is pinned, content updates between reloads
+   data threat_feed
+     from      "https://intel.example.com/feeds/blocklist.txt"
+     signed_by "data/threat_feed.pubkey.pem"
+     type      ip_list
+     format    line_separated
+     reload    interval: 1h
+   ```
+
+   For `checksum`-verified sources, the compiler verifies at compile time (and
+   again on each reload, where the policy allows) and fails the build or reload on
+   mismatch. For `signed_by` sources, the compiler verifies the detached signature
+   at every fetch; a failed verification keeps the previously loaded copy in place
+   and emits a runtime error log.
+
 ### Format Hints
 
 The `format` keyword tells the compiler how to parse the source. Defaults are inferred
@@ -336,9 +392,12 @@ Look for `*.txt`, `*.ra`, `*.mmdb` files in conventional directories and auto-im
 - **Hot-reload semantics across targets** — `reload on_change` works for Coraza
   (file watch) but not Cloud Armor (requires API push). Compiler reports unsupported
   policies per target; deployer handles target-specific provisioning.
-- **Source authenticity** — pulling data from URLs requires checksum verification
-  to prevent supply-chain attacks. The language enforces checksum declaration for
-  URL sources; without it, the compile fails.
+- **Source authenticity** — pulling data from URLs requires integrity verification
+  to prevent supply-chain attacks. The language enforces this by requiring at least
+  one of `checksum` (for content-pinned URLs) or `signed_by` (for live feeds) on
+  every URL source; without one, the compile fails. The choice between the two is
+  governed by the reload policy — pinned checksums are incompatible with live
+  reloads, since content updates necessarily change the hash.
 - **Large static data** — a 10MB IP list compiled into a SecLang `@ipMatchFromFile`
   is fine, but if the compiler tries to inline it as a regex literal, performance
   craters. Size thresholds for inline-vs-file decisions are needed.

--- a/docs/adr/0016-external-data-sources.md
+++ b/docs/adr/0016-external-data-sources.md
@@ -113,9 +113,11 @@ Three source forms:
    (per ADR-0014's path resolution rules).
 2. **`values [...]`** — inline literal values; no file involved. Useful for short
    allowlists.
-3. **`from <url>`** — load from a URL (HTTPS only, with checksum verification). Used
-   for shared threat-intel feeds. Engine-dependent: not all targets support this.
+3. **`from <url>`** — load from a URL (HTTPS only). URL sources **must** declare a
+   checksum using a sibling `checksum` field whose value is `sha256:<hex>`.
+   Example:
 
+   
 ### Format Hints
 
 The `format` keyword tells the compiler how to parse the source. Defaults are inferred
@@ -201,7 +203,7 @@ Parse errors fail the compilation with file:line context.
 |---|---|
 | `client.ip in <ip_list>` | `@ipMatchFromFile path` (file emitted alongside `.conf`) |
 | `field \|> matches_any(<regex_set>)` | `@rxFromFile path` |
-| `field \|> in_set(<string_set>)` | `@pmFromFile path` |
+| `field in <string_set>` | `@pmFromFile path` |
 | `geo_country(client.ip)` | `@geoLookup` + reference to `GEO:COUNTRY_CODE` |
 | Inline `values [...]` (small) | Expanded to a regex literal |
 | Inline `values [...]` (large) | Emitted as a generated file |


### PR DESCRIPTION
Adds four new ADRs covering structural concepts that were missing or under-specified in the prior set:

- ADR-0013: Documentation Model — four tiers (ruleset/group/rule/directive) with doc-comments for narrative + structured fields for machine-readable content. Groups nest for conceptual cohesion; cross-cutting concepts (paranoia, severity) get their own documentation blocks.
- ADR-0014: Imports and Modularity — explicit `import` directive, hierarchical namespaces for groups/macros/data, single flat namespace for rule IDs, package distribution model, compile-time conflict detection.
- ADR-0015: Macros and Named Compositions — typed expression macros, pure and inlined at compile time, file/group/package scoped. Resolves the "named composition" references scattered across earlier ADRs.
- ADR-0016: External Data Sources — typed `data` declarations for IP lists, regex sets, geo databases, regex assemblies. Replaces the implicit `@ipMatchFromFile` style with compile-time-validated references.

Also adds docs/TODO.md tracking second-tier and lower-priority structural gaps (durations, versioning, function signatures, test attachment, persistent collections, capture groups) with reserved ADR numbers.

Cleanups in existing ADRs to keep cross-references consistent:
- README: Status section, Phase 0 reframed (open vs proposed), Phase 3 table fixed (scoring_threshold → config), Pipeline operator framing softened to acknowledge Phase 0 dependency.
- ADR-0004: corrected stale claim that ADR-0011 lifts scoring_threshold to globals (it's actually ADR-0012's config block); updated example.
- ADR-0007: noted that most cited TX-only patterns are now eliminated by ADR-0006/0011/0012; added note on rule 901001 as compiler-generated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that ADRs/docs describe proposed (not ratified) designs, expanded phase roadmap and examples, swapped illustrative examples, added a TODO tracker for unresolved topics, and updated multiple ADRs for scope and wording. Added markdownlint config.

* **New Features**
  * Added proposals for a structured documentation model, typed compile-time expression macros, typed external data sources with fetch/validation semantics, and multi-file imports/modularity with conflict and override rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->