### PR TITLE
chore: update IR docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -74,11 +74,13 @@ actions:
 A rule in the new CRSLang should look like:
 
 ```
-rule 920170 (severity: warning) {
+rule 920170 {
+  metadata {
+    severity = warning
+  }
   when request.method |> matches("^(?:GET|HEAD)$")
    and request.headers["Content-Length"] |> not(matches("^0?$"))
   then block {
-    tx.anomaly_score += 5
     log()
   }
 }
@@ -91,13 +93,20 @@ the compiler emits `phase:1` automatically.
 Rules that use only cross-phase fields (e.g., `tx.*`) must declare the phase explicitly:
 
 ```
-rule 901001 (phase: request_headers, severity: critical) {
+rule 901001 {
+  metadata {
+    phase = request_headers
+    severity = critical
+  }
   when count(tx.crs_setup_version) |> eq(0)
-  then deny(status: 500)
+  then deny {
+    status: 500
+  }
 }
 ```
 
 Key properties:
+
 - **Typed fields** with dot-notation and bracket access for maps
 - **Phase inference** from field types — no redundant phase metadata
 - **Pipeline operator** (`|>`) for chaining transformations and terminal predicates
@@ -124,7 +133,7 @@ Key properties:
 5. **Incremental adoption** — each phase delivers standalone value. The project does not
    need to complete all phases to be useful.
 
-6. **Engine independence** — CRSLang describes *what* to match, not *how* a specific
+6. **Engine independence** — CRSLang describes _what_ to match, not _how_ a specific
    engine implements it. Compilation targets (Coraza, ModSecurity, cloud WAFs) are
    separate concerns. Engine configuration (body limits, PCRE tuning, log paths) is
    explicitly out of scope — it belongs in engine-specific config files, not in the rule
@@ -144,7 +153,7 @@ support globals, groups, named function compositions, and boolean conditions. Th
 trade-off is maintenance cost vs syntactic control — and the answer determines how
 Phases 2-4 are designed.
 
-**Scope:** CRSLang describes *what to detect*, not *how to run the engine*. The ~60
+**Scope:** CRSLang describes _what to detect_, not _how to run the engine_. The ~60
 SecLang configuration directives (body limits, PCRE tuning, log paths, etc.) are
 explicitly out of scope. Only rule-adjacent metadata (component signature, default
 actions, markers, app ID) stays in the language.
@@ -171,14 +180,15 @@ See [ADR-0009: Language Base Evaluation](adr/0009-language-base-evaluation.md),
 
 Replace the split `variables` + `collections` model with a unified typed field namespace.
 
-| Current | New |
-|---|---|
-| `variables: [REQUEST_METHOD]` | `request.method` |
+| Current                                                             | New                               |
+| ------------------------------------------------------------------- | --------------------------------- |
+| `variables: [REQUEST_METHOD]`                                       | `request.method`                  |
 | `collections: [{name: REQUEST_HEADERS, arguments: [Content-Type]}]` | `request.headers["Content-Type"]` |
-| `collections: [{name: TX, arguments: [score], count: true}]` | `count(tx.score)` |
-| `variables: [REMOTE_ADDR]` | `client.ip` |
+| `collections: [{name: TX, arguments: [score], count: true}]`        | `count(tx.score)`                 |
+| `variables: [REMOTE_ADDR]`                                          | `client.ip`                       |
 
 Work:
+
 - Define a typed field registry mapping dotted names to types (String, Int, IP, Bytes, Map)
 - Build bidirectional mappings: SecLang variables/collections <-> field names
 - Update the IR to use `Field` instead of separate `Variable`/`Collection`
@@ -197,13 +207,14 @@ See [ADR-0001: Typed Field Namespace](adr/0001-typed-field-namespace.md) and
 
 Replace `chain` actions and implicit logic with explicit boolean expressions.
 
-| Current | New |
-|---|---|
-| Rule + `chain` + chained rule | `condition1 and condition2` |
-| Multiple conditions (implicit OR) | `condition1 or condition2` |
-| Negated operator | `not(condition)` |
+| Current                           | New                         |
+| --------------------------------- | --------------------------- |
+| Rule + `chain` + chained rule     | `condition1 and condition2` |
+| Multiple conditions (implicit OR) | `condition1 or condition2`  |
+| Negated operator                  | `not(condition)`            |
 
 Work:
+
 - Define `Expression` as recursive: `And(Expr, Expr)`, `Or(Expr, Expr)`, `Not(Expr)`,
   `Predicate(Pipeline)`
 - Eliminate `chain` as a concept
@@ -225,8 +236,8 @@ If the custom parser is chosen, a pipeline operator (`|>`) chains them left-to-r
 If HCL is chosen, named composition functions (macros) keep nesting shallow. Either way,
 reusable transform chains are defined once and invoked by name.
 
-| Current | New (custom) | New (HCL) |
-|---|---|---|
+| Current                                                                 | New (custom)                                                | New (HCL)                          |
+| ----------------------------------------------------------------------- | ----------------------------------------------------------- | ---------------------------------- |
 | `transformations: [lowercase, urlDecode]` + `operator: {name: rx, ...}` | `field \|> url_decode() \|> lowercase() \|> matches("...")` | `matches(normalize(field), "...")` |
 
 **Structured actions and scoring** — the action bag is replaced with a structured model.
@@ -238,13 +249,14 @@ Additionally, **anomaly scoring becomes first-class**: severity-derived scoring
 eliminates the `setvar` boilerplate from every attack detection rule. A rule just declares
 its severity, and the scoring model (defined in globals) handles the rest.
 
-| Current | New |
-|---|---|
+| Current                                        | New                                       |
+| ---------------------------------------------- | ----------------------------------------- |
 | `disruptive: block` + `setvar: "tx.score=+10"` | `severity: critical` (score auto-derived) |
-| Manual `setvar` per category | Category derived from group membership |
-| Complex phase-5 evaluation rules | `scoring_threshold { inbound = 5 }` |
+| Manual `setvar` per category                   | Category derived from group membership    |
+| Complex phase-5 evaluation rules               | `scoring_threshold { inbound = 5 }`       |
 
 Work:
+
 - Define a `Function` type with signature: name, args, return type
 - If custom: implement pipeline operator, language-level macros
 - If HCL: register function library (including Sprig), define macro blocks
@@ -261,12 +273,14 @@ See [ADR-0002: Pipeline Operator](adr/0002-pipeline-operator.md) (custom parser 
 Implement the text syntax based on the Phase 0 decision.
 
 Both approaches support the core structural requirements:
+
 - **Globals block** for version, common tags — inherited by all rules
 - **Group blocks** for file-level metadata — tags shared within a logical grouping
 - **Named function compositions** (macros) — reusable transform chains
 - **Boolean conditions** with custom functions for matching
 
 Work:
+
 - If HCL: define schema, register function library, design effects model
 - If custom: write lexer + recursive-descent parser, build function library
 - YAML becomes one serialization of the IR, not the canonical form
@@ -289,6 +303,7 @@ update rule 920170 {
 ```
 
 Work:
+
 - First-class exclusion syntax
 - Rule override/extension mechanism
 - Replace `SecRuleRemoveById`, `SecRuleUpdateTargetById`, etc.
@@ -321,6 +336,7 @@ Phase 5      Full language with rule management.
 ```
 
 At every phase:
+
 - Existing SecLang `.conf` files remain importable
 - Existing v1 YAML remains loadable (with deprecation warnings from Phase 2+)
 - The playground supports all active formats
@@ -328,20 +344,20 @@ At every phase:
 
 ## Architecture Decision Records
 
-| ADR | Phase | Title | Status |
-|-----|-------|-------|--------|
-| [0009](adr/0009-language-base-evaluation.md) | 0 | Language Base — HCL, CEL, Expr, or Custom | Proposed |
-| [0008](adr/0008-configuration-directives.md) | 0 | Separation of Configuration from Rule Language | Proposed |
-| [0010](adr/0010-multi-target-compilation.md) | 0 | Multi-Target Compilation Model | Proposed |
-| [0012](adr/0012-ruleset-initialization.md) | 0 | Ruleset Initialization and Deployment Configuration | Proposed |
-| [0001](adr/0001-typed-field-namespace.md) | 1 | Typed Field Namespace | Proposed |
-| [0007](adr/0007-phase-inference.md) | 1 | Phase Inference from Field Types | Proposed |
-| [0003](adr/0003-boolean-algebra.md) | 2 | Boolean Algebra Replacing Chains | Proposed |
-| [0002](adr/0002-pipeline-operator.md) | 3 | Pipeline Operator for Composition (conditional on 0009) | Proposed |
-| [0004](adr/0004-structured-actions.md) | 3 | Structured Action Model | Proposed |
-| [0011](adr/0011-first-class-scoring.md) | 3 | First-Class Scoring Model | Proposed |
-| [0005](adr/0005-parser-strategy.md) | 4 | Parser Strategy (see 0009 for decision) | Proposed |
-| [0006](adr/0006-rule-management.md) | 5 | Rule Management Directives | Proposed |
+| ADR                                          | Phase | Title                                                   | Status   |
+| -------------------------------------------- | ----- | ------------------------------------------------------- | -------- |
+| [0009](adr/0009-language-base-evaluation.md) | 0     | Language Base — HCL, CEL, Expr, or Custom               | Proposed |
+| [0008](adr/0008-configuration-directives.md) | 0     | Separation of Configuration from Rule Language          | Proposed |
+| [0010](adr/0010-multi-target-compilation.md) | 0     | Multi-Target Compilation Model                          | Proposed |
+| [0012](adr/0012-ruleset-initialization.md)   | 0     | Ruleset Initialization and Deployment Configuration     | Proposed |
+| [0001](adr/0001-typed-field-namespace.md)    | 1     | Typed Field Namespace                                   | Proposed |
+| [0007](adr/0007-phase-inference.md)          | 1     | Phase Inference from Field Types                        | Proposed |
+| [0003](adr/0003-boolean-algebra.md)          | 2     | Boolean Algebra Replacing Chains                        | Proposed |
+| [0002](adr/0002-pipeline-operator.md)        | 3     | Pipeline Operator for Composition (conditional on 0009) | Proposed |
+| [0004](adr/0004-structured-actions.md)       | 3     | Structured Action Model                                 | Proposed |
+| [0011](adr/0011-first-class-scoring.md)      | 3     | First-Class Scoring Model                               | Proposed |
+| [0005](adr/0005-parser-strategy.md)          | 4     | Parser Strategy (see 0009 for decision)                 | Proposed |
+| [0006](adr/0006-rule-management.md)          | 5     | Rule Management Directives                              | Proposed |
 
 ## Reference Languages
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -86,6 +86,8 @@ rule 920170 {
 }
 ```
 
+The `severity = warning` metadata automatically drives anomaly scoring — no manual `setvar`/`tx.anomaly_score` adjustments are needed. (See ADR-0011 for the first-class scoring model.)
+
 The phase is not declared — it is inferred as `request_headers` (SecLang phase 1) from
 the `request.method` and `request.headers` field references. When exported to SecLang,
 the compiler emits `phase:1` automatically.

--- a/docs/README.md
+++ b/docs/README.md
@@ -99,9 +99,7 @@ rule 901001 {
     severity = critical
   }
   when count(tx.crs_setup_version) |> eq(0)
-  then deny {
-    status: 500
-  }
+  then deny(status: 500)
 }
 ```
 

--- a/docs/adr/0001-typed-field-namespace.md
+++ b/docs/adr/0001-typed-field-namespace.md
@@ -104,7 +104,7 @@ Each field has a declared type:
 | `IP`           | IP address (v4/v6)          | `client.ip`, `server.ip`                      |
 | `Bytes`        | Raw byte sequence           | `request.body`, `response.body`               |
 | `Map[String]`  | String-keyed map of strings | `request.headers`, `request.args`             |
-| `List[String]` | Ordered list of strings     | `request.headers.names`, `request.args.names` |
+| `List[String]` | Ordered list of strings     | `request.headers.keys`, `request.args.keys`   |
 | `Bool`         | Boolean                     | (future: computed fields)                     |
 
 ### Map Access

--- a/docs/adr/0001-typed-field-namespace.md
+++ b/docs/adr/0001-typed-field-namespace.md
@@ -97,25 +97,25 @@ rule.id                 # was: RULE:id (inside RULE collection)
 
 Each field has a declared type:
 
-| Type | Description | Example fields |
-|------|-------------|----------------|
-| `String` | UTF-8 text | `request.method`, `request.uri` |
-| `Int` | Integer | `response.status`, `server.port` |
-| `IP` | IP address (v4/v6) | `client.ip`, `server.ip` |
-| `Bytes` | Raw byte sequence | `request.body`, `response.body` |
-| `Map[String]` | String-keyed map of strings | `request.headers`, `request.args` |
-| `List[String]` | Ordered list of strings | `request.headers.names`, `request.args.names` |
-| `Bool` | Boolean | (future: computed fields) |
+| Type           | Description                 | Example fields                                |
+| -------------- | --------------------------- | --------------------------------------------- |
+| `String`       | UTF-8 text                  | `request.method`, `request.uri`               |
+| `Int`          | Integer                     | `response.status`, `server.port`              |
+| `IP`           | IP address (v4/v6)          | `client.ip`, `server.ip`                      |
+| `Bytes`        | Raw byte sequence           | `request.body`, `response.body`               |
+| `Map[String]`  | String-keyed map of strings | `request.headers`, `request.args`             |
+| `List[String]` | Ordered list of strings     | `request.headers.names`, `request.args.names` |
+| `Bool`         | Boolean                     | (future: computed fields)                     |
 
 ### Map Access
 
 Map-typed fields support:
+
 - **Full map** — `request.headers` (iterates all values)
 - **Key access** — `request.headers["Content-Type"]` (single value, type `String`)
-- **Names** — `request.headers.names` (list of key names)
+- **Names** — `request.headers.keys` (list of key names)
 
-**Key exclusions** (SecLang's `!ARGS:foo` — "iterate all keys except foo") are not part
-of the field syntax. Instead, target exclusions are handled by the rule management system
+**Key exclusions** (SecLang's `!ARGS:foo` — "remove foo from previously defined iterations over ARGS") are not part of the field syntax. Instead, target exclusions are handled by the rule management system
 (ADR-0006):
 
 ```

--- a/docs/adr/0002-pipeline-operator.md
+++ b/docs/adr/0002-pipeline-operator.md
@@ -46,6 +46,7 @@ field |> transform1() |> transform2() |> predicate("pattern")
 ```
 
 The pipeline reads left-to-right:
+
 1. Start with a field reference (from ADR-0001)
 2. Each `|>` passes the output of the left side as the first argument to the right side
 3. Intermediate functions (transformations) return the transformed value
@@ -54,11 +55,13 @@ The pipeline reads left-to-right:
 ### Examples
 
 **Simple match:**
+
 ```
 request.uri |> matches("^/admin")
 ```
 
 **Transformation chain:**
+
 ```
 request.headers["User-Agent"]
   |> url_decode()
@@ -68,16 +71,19 @@ request.headers["User-Agent"]
 ```
 
 **Negation:**
+
 ```
-not(request.headers["Content-Length"] |> matches("^0?$"))
+request.headers["Content-Length"] |> matches("^0?$")
 ```
 
 **Count:**
+
 ```
 count(tx.crs_setup_version) |> eq(0)
 ```
 
 **IP matching:**
+
 ```
 client.ip |> ip_in_range("10.0.0.0/8", "172.16.0.0/12")
 ```
@@ -86,59 +92,59 @@ client.ip |> ip_in_range("10.0.0.0/8", "172.16.0.0/12")
 
 #### Transformation Functions (return transformed value)
 
-| Function | Input -> Output | SecLang equivalent |
-|----------|-----------------|-------------------|
-| `lowercase()` | String -> String | `t:lowercase` |
-| `uppercase()` | String -> String | `t:uppercase` |
-| `url_decode()` | String -> String | `t:urlDecode` |
-| `url_decode_uni()` | String -> String | `t:urlDecodeUni` |
-| `html_entity_decode()` | String -> String | `t:htmlEntityDecode` |
-| `js_decode()` | String -> String | `t:jsDecode` |
-| `css_decode()` | String -> String | `t:cssDecode` |
-| `base64_decode()` | String -> String | `t:base64Decode` |
-| `hex_decode()` | String -> String | `t:hexDecode` |
+| Function                | Input -> Output  | SecLang equivalent     |
+| ----------------------- | ---------------- | ---------------------- |
+| `lowercase()`           | String -> String | `t:lowercase`          |
+| `uppercase()`           | String -> String | `t:uppercase`          |
+| `url_decode()`          | String -> String | `t:urlDecode`          |
+| `url_decode_uni()`      | String -> String | `t:urlDecodeUni`       |
+| `html_entity_decode()`  | String -> String | `t:htmlEntityDecode`   |
+| `js_decode()`           | String -> String | `t:jsDecode`           |
+| `css_decode()`          | String -> String | `t:cssDecode`          |
+| `base64_decode()`       | String -> String | `t:base64Decode`       |
+| `hex_decode()`          | String -> String | `t:hexDecode`          |
 | `compress_whitespace()` | String -> String | `t:compressWhitespace` |
-| `remove_whitespace()` | String -> String | `t:removeWhitespace` |
-| `remove_nulls()` | String -> String | `t:removeNulls` |
-| `remove_comments()` | String -> String | `t:removeComments` |
-| `normalize_path()` | String -> String | `t:normalisePath` |
-| `normalize_path_win()` | String -> String | `t:normalisePathWin` |
-| `cmd_line()` | String -> String | `t:cmdLine` |
-| `sql_hex_decode()` | String -> String | `t:sqlHexDecode` |
-| `escape_seq_decode()` | String -> String | `t:escapeSeqDecode` |
-| `trim()` | String -> String | `t:trim` |
-| `length()` | String -> Int | `t:length` |
-| `md5()` | String -> String | `t:md5` |
-| `sha1()` | String -> String | `t:sha1` |
+| `remove_whitespace()`   | String -> String | `t:removeWhitespace`   |
+| `remove_nulls()`        | String -> String | `t:removeNulls`        |
+| `remove_comments()`     | String -> String | `t:removeComments`     |
+| `normalize_path()`      | String -> String | `t:normalisePath`      |
+| `normalize_path_win()`  | String -> String | `t:normalisePathWin`   |
+| `cmd_line()`            | String -> String | `t:cmdLine`            |
+| `sql_hex_decode()`      | String -> String | `t:sqlHexDecode`       |
+| `escape_seq_decode()`   | String -> String | `t:escapeSeqDecode`    |
+| `trim()`                | String -> String | `t:trim`               |
+| `length()`              | String -> Int    | `t:length`             |
+| `md5()`                 | String -> String | `t:md5`                |
+| `sha1()`                | String -> String | `t:sha1`               |
 
 #### Predicate Functions (return bool)
 
-| Function | Input Type | SecLang equivalent |
-|----------|------------|-------------------|
-| `matches(pattern)` | String -> Bool | `@rx` |
-| `capture(pattern)` | String -> Bool | `@rx` + `capture` action (matches and stores groups) |
-| `eq(value)` | String/Int -> Bool | `@eq` / `@streq` |
-| `unconditional()` | any -> Bool | `@unconditionalMatch` (always true) |
-| `gt(value)` | Int -> Bool | `@gt` |
-| `ge(value)` | Int -> Bool | `@ge` |
-| `lt(value)` | Int -> Bool | `@lt` |
-| `le(value)` | Int -> Bool | `@le` |
-| `contains(value)` | String -> Bool | `@contains` |
-| `contains_word(values...)` | String -> Bool | `@pm` |
-| `contains_word_from_file(path)` | String -> Bool | `@pmFromFile` (external word lists) |
-| `begins_with(value)` | String -> Bool | `@beginsWith` |
-| `ends_with(value)` | String -> Bool | `@endsWith` |
-| `within(value)` | String -> Bool | `@within` |
-| `ip_in_range(ranges...)` | IP -> Bool | `@ipMatch` |
-| `ip_in_range_from_file(path)` | IP -> Bool | `@ipMatchFromFile` (external IP lists) |
-| `detect_sqli()` | String -> Bool | `@detectSQLi` |
-| `detect_xss()` | String -> Bool | `@detectXSS` |
-| `validate_byte_range(range)` | Bytes -> Bool | `@validateByteRange` |
-| `validate_url_encoding()` | String -> Bool | `@validateUrlEncoding` |
-| `validate_utf8()` | String -> Bool | `@validateUtf8Encoding` |
-| `verify_cc(pattern)` | String -> Bool | `@verifyCC` |
-| `rbl(server)` | IP -> Bool | `@rbl` |
-| `geo_lookup()` | IP -> Bool | `@geoLookup` |
+| Function                        | Input Type         | SecLang equivalent                                   |
+| ------------------------------- | ------------------ | ---------------------------------------------------- |
+| `matches(pattern)`              | String -> Bool     | `@rx`                                                |
+| `capture(pattern)`              | String -> Bool     | `@rx` + `capture` action (matches and stores groups) |
+| `eq(value)`                     | String/Int -> Bool | `@eq` / `@streq`                                     |
+| `unconditional()`               | any -> Bool        | `@unconditionalMatch` (always true)                  |
+| `gt(value)`                     | Int -> Bool        | `@gt`                                                |
+| `ge(value)`                     | Int -> Bool        | `@ge`                                                |
+| `lt(value)`                     | Int -> Bool        | `@lt`                                                |
+| `le(value)`                     | Int -> Bool        | `@le`                                                |
+| `contains(value)`               | String -> Bool     | `@contains`                                          |
+| `contains_word(values...)`      | String -> Bool     | `@pm`                                                |
+| `contains_word_from_file(path)` | String -> Bool     | `@pmFromFile` (external word lists)                  |
+| `begins_with(value)`            | String -> Bool     | `@beginsWith`                                        |
+| `ends_with(value)`              | String -> Bool     | `@endsWith`                                          |
+| `within(value)`                 | String -> Bool     | `@within`                                            |
+| `ip_in_range(ranges...)`        | IP -> Bool         | `@ipMatch`                                           |
+| `ip_in_range_from_file(path)`   | IP -> Bool         | `@ipMatchFromFile` (external IP lists)               |
+| `detect_sqli()`                 | String -> Bool     | `@detectSQLi`                                        |
+| `detect_xss()`                  | String -> Bool     | `@detectXSS`                                         |
+| `validate_byte_range(range)`    | Bytes -> Bool      | `@validateByteRange`                                 |
+| `validate_url_encoding()`       | String -> Bool     | `@validateUrlEncoding`                               |
+| `validate_utf8()`               | String -> Bool     | `@validateUtf8Encoding`                              |
+| `verify_cc(pattern)`            | String -> Bool     | `@verifyCC`                                          |
+| `rbl(server)`                   | IP -> Bool         | `@rbl`                                               |
+| `geo_lookup()`                  | IP -> Bool         | `@geoLookup`                                         |
 
 ### Type Checking
 
@@ -156,6 +162,7 @@ request.headers["Content-Length"] |> length() |> gt(100)
 ```
 
 Type errors are caught at parse time with clear messages:
+
 ```
 Error: lowercase() expects String input, got Int from 'response.status'
 ```
@@ -181,12 +188,12 @@ type FunctionCall struct {
 ```yaml
 when:
   pipeline:
-      field: request.headers["User-Agent"]
-      steps:
-        - fn: url_decode
-        - fn: lowercase
-        - fn: matches
-          args: ["malicious-pattern"]
+    field: request.headers["User-Agent"]
+    steps:
+      - fn: url_decode
+      - fn: lowercase
+      - fn: matches
+        args: ["malicious-pattern"]
 ```
 
 ## Alternatives Considered
@@ -213,6 +220,7 @@ only available syntax — HCL's grammar cannot be extended with `|>`. In that pa
 are essential to keep conditions readable.
 
 **Trade-offs vs pipeline:**
+
 - Reads inside-out for ad-hoc chains (without macros), which is opposite to CRS authors'
   mental model from SecLang's left-to-right `t:` chains
 - With macros as the steady state, the reading direction difference is minimal
@@ -226,6 +234,7 @@ request.headers["User-Agent"].urlDecode().lowercase().matches("pattern")
 ```
 
 **Considered viable but:**
+
 - Requires fields to be objects with methods, complicating the type system
 - Dot already used for field hierarchy (ADR-0001), adding method calls on the same
   syntax creates ambiguity: is `request.headers.names` a field or a method?
@@ -238,6 +247,7 @@ request.uri | lowercase | matches("pattern")
 ```
 
 **Rejected because:**
+
 - `|` is commonly used for bitwise OR or alternatives in regex context
 - Could create parsing ambiguity with future boolean OR syntax
 - `|>` is established in Elixir, F#, OCaml, and Gleam for this exact purpose

--- a/docs/adr/0002-pipeline-operator.md
+++ b/docs/adr/0002-pipeline-operator.md
@@ -70,12 +70,6 @@ request.headers["User-Agent"]
   |> matches("malicious-pattern")
 ```
 
-**Negation:**
-
-```
-request.headers["Content-Length"] |> matches("^0?$")
-```
-
 **Count:**
 
 ```

--- a/docs/adr/0002-pipeline-operator.md
+++ b/docs/adr/0002-pipeline-operator.md
@@ -41,7 +41,7 @@ transformations and operators become functions connected by the pipeline.
 
 ### Syntax
 
-```
+```text
 field |> transform1() |> transform2() |> predicate("pattern")
 ```
 
@@ -56,13 +56,13 @@ The pipeline reads left-to-right:
 
 **Simple match:**
 
-```
+```text
 request.uri |> matches("^/admin")
 ```
 
 **Transformation chain:**
 
-```
+```text
 request.headers["User-Agent"]
   |> url_decode()
   |> lowercase()
@@ -72,13 +72,13 @@ request.headers["User-Agent"]
 
 **Count:**
 
-```
+```text
 count(tx.crs_setup_version) |> eq(0)
 ```
 
 **IP matching:**
 
-```
+```text
 client.ip |> ip_in_range("10.0.0.0/8", "172.16.0.0/12")
 ```
 
@@ -144,7 +144,7 @@ client.ip |> ip_in_range("10.0.0.0/8", "172.16.0.0/12")
 
 The pipeline enables static type checking:
 
-```
+```text
 # Valid: String -> String -> String -> Bool
 request.uri |> lowercase() |> url_decode() |> matches("pattern")
 
@@ -157,7 +157,7 @@ request.headers["Content-Length"] |> length() |> gt(100)
 
 Type errors are caught at parse time with clear messages:
 
-```
+```text
 Error: lowercase() expects String input, got Int from 'response.status'
 ```
 
@@ -194,14 +194,14 @@ when:
 
 ### A: Nested Function Calls (Wirefilter-style)
 
-```
+```text
 matches(lowercase(url_decode(request.headers["User-Agent"])), "pattern")
 ```
 
 **Viable with macros (see ADR-0009).** The original concern about deep nesting dissolves
 when named composition functions keep calls at 1-2 levels:
 
-```
+```text
 # Without macros: 4 levels deep, hard to read
 matches(lowercase(url_decode(js_decode(request.args))), "pattern")
 
@@ -223,7 +223,7 @@ are essential to keep conditions readable.
 
 ### B: Method Chaining (CEL-style)
 
-```
+```text
 request.headers["User-Agent"].urlDecode().lowercase().matches("pattern")
 ```
 
@@ -236,7 +236,7 @@ request.headers["User-Agent"].urlDecode().lowercase().matches("pattern")
 
 ### C: Unix Pipe (`|`)
 
-```
+```text
 request.uri | lowercase | matches("pattern")
 ```
 

--- a/docs/adr/0003-boolean-algebra.md
+++ b/docs/adr/0003-boolean-algebra.md
@@ -64,7 +64,7 @@ grouping.
 ### Syntax
 
 ```
-rule 920170 (phase: request_headers) {
+rule 920170 {
   metadata {
     phase: request_headers
   }

--- a/docs/adr/0003-boolean-algebra.md
+++ b/docs/adr/0003-boolean-algebra.md
@@ -25,9 +25,9 @@ metadata:
   id: 920170
 conditions:
   - variables: [REQUEST_METHOD]
-    operator: {name: rx, value: "^(?:GET|HEAD)$"}
+    operator: { name: rx, value: "^(?:GET|HEAD)$" }
 actions:
-  disruptive: {action: block}
+  disruptive: { action: block }
   flow: [chain]
 chainedRule:
   kind: rule
@@ -35,7 +35,7 @@ chainedRule:
     - collections:
         - name: REQUEST_HEADERS
           arguments: [Content-Length]
-      operator: {negate: true, name: rx, value: "^0?$"}
+      operator: { negate: true, name: rx, value: "^0?$" }
   actions:
     non-disruptive:
       - action: setvar
@@ -64,9 +64,13 @@ grouping.
 ### Syntax
 
 ```
-rule 920170 (phase: request) {
-  when request.method |> matches("^(?:GET|HEAD)$")
-   and request.headers["Content-Length"] |> not(matches("^0?$"))
+rule 920170 (phase: request_headers) {
+  metadata {
+    phase: request_headers
+  }
+  let condition1 = request.method |> matches("^(?:GET|HEAD)$")
+  let condition2 = request.headers["Content-Length"] |> matches("^0?$")
+  when condition1 and condition2
   then block {
     tx.anomaly_score += 5
   }
@@ -76,6 +80,7 @@ rule 920170 (phase: request) {
 ### Operator Precedence
 
 From highest to lowest:
+
 1. `not` (unary)
 2. `and`
 3. `or`
@@ -156,7 +161,7 @@ SecRule REQUEST_HEADERS:Range "@rx (\d+)-(\d+)" \
 
 Here `capture` must execute when the first condition matches (not when the full chain
 matches), because captured groups are consumed downstream. However, the captured values
-are only *useful* if the full chain matches. In the boolean model, `capture()` becomes a
+are only _useful_ if the full chain matches. In the boolean model, `capture()` becomes a
 pipeline function that extracts groups as a side-effect of matching:
 
 ```
@@ -295,6 +300,7 @@ Use a **layered approach**:
 #### Execution Semantics (if Option B is adopted)
 
 If conditional side-effects are added:
+
 - Side-effects on a predicate execute **when that predicate evaluates to true** during
   expression evaluation.
 - Evaluation order is **left-to-right** with **short-circuit**: `A and B` does not
@@ -361,41 +367,33 @@ then pass { init_collection(ip: client.ip + "_" + ua_hash) }
 
 ### Collection Quantifier: `each()`
 
-SecLang's `multiMatch` action changes how a collection-targeting condition evaluates —
-instead of stopping at the first match, it iterates all values and fires side-effects
-per match. This is currently modeled as a non-disruptive action, but it is semantically
-a condition quantifier.
+SecLang's `multiMatch` action changes how an operator evaluates a target that has transformations —
+instead of evaluating after applying the transformations, are checked against the operator before and after every transformation function. This is currently modeled as a non-disruptive action, but it is semantically
+a flow control mechanism.
 
-**Recommendation: `each()` as a condition-level quantifier (Option A).**
+**Recommendation: `multi_match` as a metadata property.**
 
 ```
-# Without each(): first match wins, effects fire once
-when request.args |> detect_sqli()
+# Without multi_match: transformations pipeline is evaluated once, operator tests final output
+when request.args |> lowercase() |> remove_whitespace() |> detect_sqli()
 
-# With each(): all values tested, effects fire per match
-when each(request.args) |> detect_sqli()
+# With multiMatch(): operator tests original value and after each transformation
+metadata {
+  multi_match = true
+}
+when request.args |> lowercase() |> remove_whitespace() |> detect_sqli()
 then block {
   tx.sqli_score += 5     # incremented per matching argument
   log(data: matched.var)  # logged per matching argument
 }
 ```
 
-`each()` wraps a map-typed field and signals "iterate all values." Without it, the
-default is first-match semantics.
-
 **Alternatives documented:**
 
-- **Option B: Effect-level modifier** — `then block (per_match: true) { ... }`. Simpler
-  to parse but misleading: the reader assumes first-match from the condition until
-  they notice the modifier.
-- **Option C: Separate iteration block** — `for each match { per-match effects } then
-  block { once-only effects }`. Most expressive (supports both per-match and once-only
-  effects) but adds a new block type.
-- **Option D: Drop it** — if scoring becomes first-class (ADR-0011), per-match scoring
-  may be handled at the scoring level rather than as a language construct.
+- **Option B: pipeline function** — `multi_match(lowercase, remove_whitespace)`. Remove the need of a metadata property but it adds complexity to the pipeline syntax.
 
 `multiMatch` is rarely used in CRS, so Option A is sufficient for the foreseeable
-future. Options B/C can be revisited if use cases emerge.
+future. Option B can be revisited if use cases emerge.
 
 ### String Interpolation
 
@@ -416,9 +414,12 @@ Boolean algebra enables patterns that are impossible or awkward in SecLang:
 ```
 # OR conditions (currently requires separate rules + scoring)
 rule 100001 (phase: request) {
-  when request.uri |> matches("/admin")
-   and (client.ip |> ip_in_range("10.0.0.0/8")
-        or request.headers["X-Internal"] |> eq("true"))
+  let is_admin_path = request.uri |> matches("/admin")
+  let is_internal_client = client.ip |> ip_in_range("10.0.0.0/8")
+  let has_internal_header = request.headers["X-Internal"] |> eq("true")
+  when is_admin_path
+   and (is_internal_client
+        or has_internal_header)
   then pass
 }
 
@@ -466,6 +467,7 @@ then:
 Add `or_chain` alongside `chain` to keep the sequential model but add OR support.
 
 **Rejected because:**
+
 - Does not address nesting depth problem
 - Creates a hybrid model that is harder to reason about than either pure chains or
   pure boolean algebra
@@ -484,6 +486,7 @@ rule 920170 {
 ```
 
 **Rejected because:**
+
 - Implicit AND with no explicit OR creates the same asymmetry as SecLang
 - Harder to parse: where does one condition end and the next begin?
 - Less familiar to the target audience
@@ -498,6 +501,7 @@ match request {
 ```
 
 **Rejected because:**
+
 - Only works for AND conditions on the same request
 - Cannot express cross-category conditions (request + response + tx)
 - Novel syntax with no established precedent

--- a/docs/adr/0004-structured-actions.md
+++ b/docs/adr/0004-structured-actions.md
@@ -61,7 +61,7 @@ Each disruptive action can take named parameters:
 
 ```
 then deny(status: 403)
-then block(status: 403)
+then block
 then redirect(url: "https://example.com/blocked")
 then drop
 then pass
@@ -84,7 +84,8 @@ ip.reput_block_flag = 1        # was: setvar:'ip.reput_block_flag=1'
 ```
 
 Assignment operators:
-- `=`  — set (was: `setvar:'collection.var=value'`)
+
+- `=` — set (was: `setvar:'collection.var=value'`)
 - `+=` — increment (was: `setvar:'collection.var=+value'`)
 - `-=` — decrement (was: `setvar:'collection.var=-value'`)
 
@@ -135,6 +136,7 @@ configure(request_body_processor: XML)
 ### Complete Examples
 
 **Simple block with scoring** (severity-derived, per ADR-0011):
+
 ```
 group "xss_detection" {
   category = "xss"
@@ -166,6 +168,7 @@ rule 941100 (severity: critical) {
 **Pass with configuration** (setup-style rule, kept for illustrating direct TX
 assignment; note that ADR-0011 lifts `scoring_threshold` and global paranoia settings
 out of rules into a `globals` block):
+
 ```
 rule 900100 (phase: request_headers) {
   when true
@@ -177,6 +180,7 @@ rule 900100 (phase: request_headers) {
 ```
 
 **Deny with status:**
+
 ```
 rule 901001 (phase: request_headers, severity: critical) {
   when count(tx.crs_setup_version) |> eq(0)
@@ -277,6 +281,7 @@ actions:
 ```
 
 **Rejected because:**
+
 - Still carries the category model that confuses authors
 - Does not solve the fundamental problem of actions being a grab-bag
 
@@ -291,7 +296,8 @@ then {
 ```
 
 **Rejected because:**
-- The disruptive action is not a side-effect; it is the *outcome* of the rule.
+
+- The disruptive action is not a side-effect; it is the _outcome_ of the rule.
   It deserves syntactic prominence, not burial in a block.
 - `deny()` as a function call implies it could appear conditionally inside the block,
   which should not be possible.

--- a/docs/adr/0007-phase-inference.md
+++ b/docs/adr/0007-phase-inference.md
@@ -76,11 +76,20 @@ when needed. It can be overridden in metadata.**
 
 ### Conflict Detection
 
-If a rule references fields from multiple phases, the inferred phase is the latest phase needed to have all referenced fields available:
+If a rule references fields from multiple phases, the inferred phase is the latest phase needed to have all referenced fields available. For example, a rule referencing both `request.headers` (phase 1) and `request.body` (phase 2) is inferred as `request_body`:
 
-If a rule explicitly define a phase and references targets that are not available in that phase, it is a compile error:
-
+```text
+# Phase is inferred as request_body (latest of request_headers and request_body)
+rule 920180 {
+  when request.headers["Content-Type"] |> matches("^application/json")
+   and request.body |> contains("malicious")
+  then block
+}
 ```
+
+If a rule explicitly declares a phase and references targets that are not available in that phase, it is a compile error:
+
+```text
 # ERROR: response.body is not available in phase request_headers
 rule 999999 {
   metadata {
@@ -100,7 +109,7 @@ at compile time.
 
 When a rule mixes phase-specific and cross-phase fields, the phase-specific field wins:
 
-```
+```text
 # Phase is inferred as request_headers (from request.method)
 # tx.anomaly_score is cross-phase, so it does not affect inference
 rule 920170 {
@@ -115,7 +124,7 @@ rule 920170 {
 When inference is not possible (TX-only rules) or when the author wants to override for
 clarity, phase is declared in metadata:
 
-```
+```text
 # Must declare phase — only TX fields used
 rule 901001 {
   metadata {
@@ -151,7 +160,7 @@ CRSLang uses descriptive phase names instead of numbers:
 When exporting to SecLang, the compiler maps inferred or declared phases back to numeric
 values. This is lossless:
 
-```
+```text
 # CRSLang (phase inferred from request.headers)
 rule 920170 {
   when request.headers["Content-Type"] |> matches("^application/json")
@@ -165,9 +174,12 @@ SecRule REQUEST_HEADERS:Content-Type "@rx ^application/json" \
 
 For rules with explicit phase:
 
-```
+```text
 # CRSLang
-rule 901001 (phase: request_headers) {
+rule 901001 {
+  metadata {
+    phase = request_headers
+  }
   when count(tx.crs_setup_version) |> eq(0)
   then deny(status: 500)
 }
@@ -226,7 +238,7 @@ Always infer, error on TX-only rules that cannot be inferred.
 
 ### C: Phase as a rule attribute, not metadata
 
-```
+```text
 @phase(request_headers)
 rule 901001 { ... }
 ```

--- a/docs/adr/0007-phase-inference.md
+++ b/docs/adr/0007-phase-inference.md
@@ -9,13 +9,13 @@
 SecLang requires every rule to declare a numeric phase (1-5) that controls when the rule
 evaluates during request processing:
 
-| Phase | Name | Available data |
-|-------|------|----------------|
-| 1 | Request Headers | Method, URI, headers, cookies, query string args |
-| 2 | Request Body | POST body, file uploads, multipart data |
-| 3 | Response Headers | Response status, response headers |
-| 4 | Response Body | Response body content |
-| 5 | Logging | Post-processing (rarely used in rules) |
+| Phase | Name             | Available data                                   |
+| ----- | ---------------- | ------------------------------------------------ |
+| 1     | Request Headers  | Method, URI, headers, cookies, query string args |
+| 2     | Request Body     | POST body, file uploads, multipart data          |
+| 3     | Response Headers | Response status, response headers                |
+| 4     | Response Body    | Response body content                            |
+| 5     | Logging          | Post-processing (rarely used in rules)           |
 
 In CRSLang v1 phase is a string in metadata:
 
@@ -32,20 +32,20 @@ must be phase 4. The phase is already implied by the fields the rule references.
 
 With the typed field namespace from ADR-0001:
 
-| Field prefix | Implied phase | SecLang phase |
-|---|---|---|
-| `request.method`, `request.uri`, `request.protocol`, `request.line` | request_headers | 1 |
-| `request.headers[*]`, `request.cookies[*]` | request_headers | 1 |
-| `request.args.get[*]`, `request.args.get.names` | request_headers | 1 |
-| `request.body`, `request.args.post[*]`, `request.args[*]` | request_body | 2 |
-| `multipart.*`, `files.*` | request_body | 2 |
-| `response.status`, `response.protocol` | response_headers | 3 |
-| `response.headers[*]` | response_headers | 3 |
-| `response.body` | response_body | 4 |
-| `tx.*`, `ip.*`, `global.*`, `session.*` | any (cross-phase) | context-dependent |
-| `matched.*`, `rule.*` | any (cross-phase) | context-dependent |
-| `client.ip`, `server.*` | any (cross-phase) | context-dependent |
-| `time.*`, `env.*` | any (cross-phase) | context-dependent |
+| Field prefix                                                        | Implied phase     | SecLang phase     |
+| ------------------------------------------------------------------- | ----------------- | ----------------- |
+| `request.method`, `request.uri`, `request.protocol`, `request.line` | request_headers   | 1                 |
+| `request.headers[*]`, `request.cookies[*]`                          | request_headers   | 1                 |
+| `request.args.get[*]`, `request.args.get.names`                     | request_headers   | 1                 |
+| `request.body`, `request.args.post[*]`, `request.args[*]`           | request_body      | 2                 |
+| `multipart.*`, `files.*`                                            | request_body      | 2                 |
+| `response.status`, `response.protocol`                              | response_headers  | 3                 |
+| `response.headers[*]`                                               | response_headers  | 3                 |
+| `response.body`                                                     | response_body     | 4                 |
+| `tx.*`, `ip.*`, `global.*`, `session.*`                             | any (cross-phase) | context-dependent |
+| `matched.*`, `rule.*`                                               | any (cross-phase) | context-dependent |
+| `client.ip`, `server.*`                                             | any (cross-phase) | context-dependent |
+| `time.*`, `env.*`                                                   | any (cross-phase) | context-dependent |
 
 ### Phase-Ambiguous Fields
 
@@ -54,6 +54,7 @@ Some fields are available in all phases. When a rule uses **only** cross-phase f
 explicitly.
 
 In CRS, this pattern appears in:
+
 - Initialization rules (phase 1, TX-only) — e.g., rule 901001 checking
   `count(tx.crs_setup_version)`
 - Paranoia level skip rules (phase 1-4, TX-only) — e.g., rules 911011/911012 checking
@@ -63,7 +64,7 @@ In CRS, this pattern appears in:
 ## Decision
 
 **Phase is inferred from field references when unambiguous, and explicitly declared only
-when needed.**
+when needed. It can be overridden in metadata.**
 
 ### Inference Rules
 
@@ -75,11 +76,16 @@ when needed.**
 
 ### Conflict Detection
 
-If a rule references fields from multiple phases, that is a **compile-time error**:
+If a rule references fields from multiple phases, the inferred phase is the latest phase needed to have all referenced fields available:
+
+If a rule explicitly define a phase and references targets that are not available in that phase, it is a compile error:
 
 ```
-# ERROR: request.method is phase 1, response.body is phase 4
+# ERROR: response.body is not available in phase request_headers
 rule 999999 {
+  metadata {
+    phase = request_headers
+  }
   when request.method |> eq("GET")
    and response.body |> contains("error")
   then block
@@ -111,7 +117,11 @@ clarity, phase is declared in metadata:
 
 ```
 # Must declare phase — only TX fields used
-rule 901001 (phase: request_headers) {
+rule 901001 {
+  metadata {
+    phase = request_headers
+  }
+
   when count(tx.crs_setup_version) |> eq(0)
   then deny(status: 500)
 }
@@ -128,20 +138,13 @@ group "method_enforcement_pl1" (requires: paranoia >= 1) {
 
 CRSLang uses descriptive phase names instead of numbers:
 
-| CRSLang name | SecLang number |
-|---|---|
-| `request_headers` | 1 |
-| `request_body` | 2 |
-| `response_headers` | 3 |
-| `response_body` | 4 |
-| `logging` | 5 |
-
-The text syntax also accepts short forms for ergonomics:
-
-| Short form | Full name |
-|---|---|
-| `request` | `request_headers` (most common request phase) |
-| `response` | `response_headers` (most common response phase) |
+| CRSLang name       | SecLang number |
+| ------------------ | -------------- |
+| `request_headers`  | 1              |
+| `request_body`     | 2              |
+| `response_headers` | 3              |
+| `response_body`    | 4              |
+| `logging`          | 5              |
 
 ### Compilation to SecLang
 
@@ -182,6 +185,7 @@ available in phase 1, but POST parameters are only populated after phase 2 proce
 body.
 
 CRSLang resolves this:
+
 - `request.args.get` → unambiguously phase 1 (query string only)
 - `request.args.post` → unambiguously phase 2 (POST body only)
 - `request.args` (combined) → inferred as phase 2 (the latest phase needed to have
@@ -203,6 +207,7 @@ would produce false negatives on POST-based attacks.
 Keep phase as a required metadata field, even when it can be inferred.
 
 **Rejected because:**
+
 - Redundant in 80%+ of rules
 - Creates a maintenance burden: if a rule's targets change, the author must remember
   to update the phase
@@ -214,6 +219,7 @@ Keep phase as a required metadata field, even when it can be inferred.
 Always infer, error on TX-only rules that cannot be inferred.
 
 **Rejected because:**
+
 - TX-only rules are common in CRS (initialization, scoring, paranoia skipping)
 - Some rules intentionally run in specific phases for ordering reasons
 - Removes author control where it is legitimately needed
@@ -226,6 +232,7 @@ rule 901001 { ... }
 ```
 
 **Rejected because:**
+
 - Adds syntax weight for something that is usually inferred
 - Attributes/annotations are better reserved for cross-cutting concerns that affect
   many rules (e.g., `@deprecated`, `@disabled`)
@@ -239,7 +246,7 @@ rule 901001 { ... }
   becomes a compile error in CRSLang
 - Descriptive phase names (`request_headers`) are clearer than numeric phases (`1`)
 - Lossless round-trip to SecLang: the compiler maps inferred phases to numbers
-- Reduces cognitive load: authors think about *what* data to inspect, not *when* the
+- Reduces cognitive load: authors think about _what_ data to inspect, not _when_ the
   engine should inspect it
 
 ### Negative

--- a/docs/adr/0010-multi-target-compilation.md
+++ b/docs/adr/0010-multi-target-compilation.md
@@ -46,7 +46,7 @@ and reports clear errors for unsupported features.
    ModSecurity/Coraza today), not a language constraint.
 
 3. **Graceful degradation** — when a CRSLang feature has no equivalent in a target:
-   - By default, the compiler tries to compile all rules for the target backend, however if a rule has the properties `backends` specified, the compiler will only attempt to compile it if the target is included in the list. This allows CRS consumers to know which rules are expected in their target and which are not.
+   - By default, the compiler tries to compile all rules for the target backend, however if a rule has the `backends` metadata property specified (planned — not yet implemented), the compiler will only attempt to compile it if the target is included in the list. This allows CRS consumers to know which rules are expected in their target and which are not.
    - If there's a workaround (e.g., OR → multiple rules with scoring for SecLang),
      the compiler applies it automatically.
    - If there's no workaround, the compiler emits a clear error: "Feature X is not

--- a/docs/adr/0010-multi-target-compilation.md
+++ b/docs/adr/0010-multi-target-compilation.md
@@ -9,12 +9,12 @@
 CRSLang's primary compilation target today is SecLang (ModSecurity/Coraza `.conf` files).
 However, the long-term vision is to compile CRSLang rules to multiple WAF engines:
 
-| Target | Expression language | Organization |
-|--------|-------------------|--------------|
-| ModSecurity / Coraza | SecLang directives | OWASP |
-| Google Cloud Armor | CEL expressions | Google Cloud |
-| AWS WAF | JSON rule statements | AWS |
-| Cloudflare WAF | Wirefilter expressions | Cloudflare |
+| Target               | Expression language    | Organization |
+| -------------------- | ---------------------- | ------------ |
+| ModSecurity / Coraza | SecLang directives     | OWASP        |
+| Google Cloud Armor   | CEL expressions        | Google Cloud |
+| AWS WAF              | JSON rule statements   | AWS          |
+| Cloudflare WAF       | Wirefilter expressions | Cloudflare   |
 
 Each target has a different expression language, different capabilities, and different
 limitations. CRSLang must be expressive enough to author rules once and compile them to
@@ -46,6 +46,7 @@ and reports clear errors for unsupported features.
    ModSecurity/Coraza today), not a language constraint.
 
 3. **Graceful degradation** — when a CRSLang feature has no equivalent in a target:
+   - By default, the compiler tries to compile all rules for the target backend, however if a rule has the properties `backends` specified, the compiler will only attempt to compile it if the target is included in the list. This allows CRS consumers to know which rules are expected in their target and which are not.
    - If there's a workaround (e.g., OR → multiple rules with scoring for SecLang),
      the compiler applies it automatically.
    - If there's no workaround, the compiler emits a clear error: "Feature X is not
@@ -73,20 +74,20 @@ existing backends or the language itself.
 
 ### Feature Support Matrix (Expected)
 
-| Feature | SecLang | Cloud Armor | AWS WAF | Cloudflare |
-|---------|---------|-------------|---------|------------|
-| Boolean AND | chain (workaround) | native | native | native |
-| Boolean OR | separate rules (workaround) | native | native | native |
-| Regex matching | native | native | native | native |
-| String transforms | native (40+) | limited | very limited | limited |
-| IP matching | native | native | native | native |
-| Anomaly scoring | via TX variables | not native | not native | not native |
-| `detect_sqli()` | native (libinjection) | not available | managed rules | managed rules |
-| `detect_xss()` | native (libinjection) | not available | managed rules | managed rules |
-| Response body inspection | native | not available | not available | limited |
-| `ctl:` runtime overrides | native | not available | not available | not available |
-| File-based pattern lists | native (`@pmFromFile`) | not available | not available | not available |
-| Rule exclusions | native | custom | custom | custom |
+| Feature                  | SecLang                     | Cloud Armor   | AWS WAF       | Cloudflare    |
+| ------------------------ | --------------------------- | ------------- | ------------- | ------------- |
+| Boolean AND              | chain (workaround)          | native        | native        | native        |
+| Boolean OR               | separate rules (workaround) | native        | native        | native        |
+| Regex matching           | native                      | native        | native        | native        |
+| String transforms        | native (40+)                | limited       | very limited  | limited       |
+| IP matching              | native                      | native        | native        | native        |
+| Anomaly scoring          | via TX variables            | not native    | not native    | not native    |
+| `detect_sqli()`          | native (libinjection)       | not available | managed rules | managed rules |
+| `detect_xss()`           | native (libinjection)       | not available | managed rules | managed rules |
+| Response body inspection | native                      | not available | not available | limited       |
+| `ctl:` runtime overrides | native                      | not available | not available | not available |
+| File-based pattern lists | native (`@pmFromFile`)      | not available | not available | not available |
+| Rule exclusions          | native                      | custom        | custom        | custom        |
 
 ### SecLang-Specific Considerations
 
@@ -94,7 +95,7 @@ Because SecLang is the primary target and has the most constraints, the compiler
 handle several CRSLang features that SecLang cannot express directly:
 
 **Boolean OR** — CRSLang's `A or B` has no SecLang equivalent. The compiler decomposes
-it into separate rules with shared scoring:
+it into separate rules, each condition rule will set a variable if it matches, and a final rule checks the variable to apply the disruptive action. The final rule will use the CRSLang id:
 
 ```
 # CRSLang
@@ -105,8 +106,9 @@ rule 100001 {
 
 # Compiled SecLang: two rules, same score target
 # Rule IDs must be integers; the compiler allocates adjacent IDs deterministically.
-SecRule ... "id:1000011,...,setvar:'tx.anomaly_score=+5'"
-SecRule ... "id:1000012,...,setvar:'tx.anomaly_score=+5'"
+SecRule ... "id:1000011,...,setvar:'tx.internal_rule_1000011=1'"
+SecRule ... "id:1000012,...,setvar:'tx.internal_rule_1000012=1'"
+SecRule TX:internal_rule_1000011||TX:internal_rule_1000012 "@eq 1" "id:100001,...,deny"
 ```
 
 **Macros / named compositions** — expanded inline during compilation. The compiled
@@ -153,6 +155,7 @@ Limit CRSLang to what SecLang can express. No OR, no macros, no features beyond 
 compiles 1:1.
 
 **Rejected because:**
+
 - Defeats the purpose of a new language
 - Cloud WAF targets natively support OR, grouping, and richer expressions
 - CRS maintainers cannot express patterns they can think of
@@ -163,6 +166,7 @@ compiles 1:1.
 Limit CRSLang to features supported by every target.
 
 **Rejected because:**
+
 - The intersection is too small (string transforms, regex, IP matching, basic AND)
 - Cloud WAF targets have very different capabilities
 - Would prevent CRS from using features like `detect_sqli()` which only some engines
@@ -174,6 +178,7 @@ Limit CRSLang to features supported by every target.
 Define subsets of CRSLang for each target (e.g., "CRSLang-SecLang", "CRSLang-CEL").
 
 **Rejected because:**
+
 - Fragments the language and the community
 - Rule authors must know which profile they're writing for
 - Tooling must handle multiple profiles


### PR DESCRIPTION
## Discussion points
- Add a metadata section to rules, including phase, severity, potential backends, and rule tags. This removes the need for arguments in the rule constructor.
- Prevent (or at least provide a way to avoid) mixing pipeline syntax with boolean algebra, as it can be confusing. Both syntaxes are promising on their own, but combining them is likely to lead to errors. The let operator could be useful to separate multiple conditions.
- Fix phase inference. Supporting multiple phase targets could be useful. The heuristic should define the phase based on the latest target's phase. Users should also be able to override the inferred phase if the new phase value is greater than the inferred one.
- Avoid using short names for phases, as they can be misleading. For example, `request` should not be a shorthand for `request_headers`, since in HTTP request includes both request_headers and request_body.
- Fix multi_match based on SecLang definitions, and introduce a new proposal if needed.
- Improve OR compilation for SecLang with TX. In some cases, it could be optimized (for example, when different conditions share the same operator, they could be compiled into a single rule).
- From my point of view, ctl should be removed from rule actions in the IR. The only behavior that affects rule definition is updating targets with ctl, which is already covered by other syntax (update and remove).
- Introduce a new metadata parameter `backends` to restrict which backends can use a given rule. Its main purpose is to make explicit to users which rules are supported by each backend. By default, the compiler will attempt to compile all rules that do not define the backends parameter.

I haven’t updated all the examples with the proposed changes yet. Let’s discuss these points first, and then I will update the examples.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Moved severity and phase settings into metadata blocks and noted severity now drives anomaly scoring automatically
  * Removed a manual anomaly-score adjustment from examples
  * Clarified phase inference when rules reference multiple phases
  * Described backend-aware rule compilation behavior
  * Improved formatting, tables and examples across ADRs for typed-field namespace, pipeline, boolean algebra, and structured actions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->